### PR TITLE
Fixes #107 - Check in bootstrap.php if this is a behat environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ https://github.com/catalyst/moodle-auth_outage/issues
 enable the `Outage manager` plugin and place it on the top.
 
 4. If you need to use the IP Blocking, please add the following lines into your `config.php`
-after your `$CFG->dataroot` is set:
+before the `require('/lib/setup.php')` call:
 
 ```
 // Insert this after $CFG->dataroot is defined.


### PR DESCRIPTION
Most of the code added is inside a `if` that should never be triggered in production sites, as they should not have behat configured. Even if they have, it should work fine (as in development environment).

I got the code from: https://github.com/moodle/moodle/blob/master/lib/setup.php#L79-L143

The idea of copying the $CFG and restoring later is because `lib/setup.php` does much more than just checking if the environment is behat, it does some initialisation as well. I just want to set the proper variables while running the callback function (step 2) and the climaintenance.php (step 3). After that, ignore my changes to `$CFG` and let `lib/setup.php` do its job.

Check issue #107 for more info.