### PR TITLE
Issue 95 core maintenance warning

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,8 @@
+/**
+ * Globally supress core Moodle maintenance warning message.
+ *
+ * Note that this can be explicitly overridden by themes.
+ */
+.box.moodle-has-zindex.maintenancewarning {
+    display: none;
+}

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = "auth_outage";
-$plugin->version = 2017051800;                  // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release = '1.0.8';                     // Human-readable release information.
+$plugin->version = 2017071300;                  // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release = '1.0.9';                     // Human-readable release information.
 $plugin->requires = 2014051200;                 // Requires Moodle 2.7 or later. Moodle 3.0 or later recommended.
 $plugin->maturity = MATURITY_STABLE;            // Suitable for PRODUCTION environments!


### PR DESCRIPTION
Add styles.css to globally suppress the existing core Moodle maintenance warning message.