### PR TITLE
Adding check for use of ip restrictions before warning

### DIFF
--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -330,7 +330,7 @@ EOT;
 
         $message = [];
 
-        if (!isset($CFG->auth_outage_bootstrap_loaded) || !$CFG->auth_outage_bootstrap_loaded) {
+        if (trim(outagelib::get_config()->allowedips) != '' && (!isset($CFG->auth_outage_bootstrap_loaded) || !$CFG->auth_outage_bootstrap_loaded)) {
             $message[] = get_string('configurationwarning', 'auth_outage');
         }
 


### PR DESCRIPTION
Check if ip restrictions are configured before complaining about bootstrap.php not being included in config.php.