### PR TITLE
Do not check event calendar capability when running cli/finish.php

### DIFF
--- a/classes/calendar/calendar.php
+++ b/classes/calendar/calendar.php
@@ -65,7 +65,7 @@ class calendar {
             debugging('Cannot update calendar entry for outage #'.$outage->id.', event not found. Creating it...');
             self::create($outage);
         } else {
-            $event->update(self::create_data($outage));
+            $event->update(self::create_data($outage), false);
         }
     }
 


### PR DESCRIPTION
This PR fixes #170 

There is no point to check event calendar capability when we finish outage via UI as we have admin checks [here](https://github.com/catalyst/moodle-auth_outage/blob/6e960e8814e51a1f69bc09c103fc79529b7d122c/finish.php#L34) and [here](https://github.com/catalyst/moodle-auth_outage/blob/6e960e8814e51a1f69bc09c103fc79529b7d122c/views/warningbar/warningbar.php#L48).

When running cli script `php auth/outage/cli/finish.php --active` we don't check any permissions so don't think that checking event calendar capability when the half of work has been done (outage record has been updated on database level [here](https://github.com/catalyst/moodle-auth_outage/blob/6e960e8814e51a1f69bc09c103fc79529b7d122c/classes/dml/outagedb.php#L128) ) makes any sense.