### PR TITLE
Fix events that trigger re-enabling maintenance mode

### DIFF
--- a/classes/dml/outagedb.php
+++ b/classes/dml/outagedb.php
@@ -135,7 +135,7 @@ class outagedb {
         }
 
         // Trigger outages modified events.
-        outagelib::prepare_next_outage();
+        outagelib::prepare_next_outage(true);
 
         // All done, return the id.
         return $outage->id;

--- a/classes/form/outage/edit.php
+++ b/classes/form/outage/edit.php
@@ -163,10 +163,16 @@ class edit extends moodleform {
                 $this->_form->addElement('html',
                     $OUTPUT->notification(get_string('warningreenablemaintenancemode', 'auth_outage'), 'notifywarning'));
             }
-
-            $this->add_action_buttons();
         } else {
             throw new coding_exception('$outage must be an outage object.', $outage);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see moodleform::definition_after_data()
+     */
+    public function definition_after_data() {
+        $this->add_action_buttons();
     }
 }

--- a/classes/form/outage/edit.php
+++ b/classes/form/outage/edit.php
@@ -82,6 +82,9 @@ class edit extends moodleform {
         $mform->addHelpButton('description', 'description', 'auth_outage');
 
         $mform->addElement('static', 'usagehints', '', get_string('textplaceholdershint', 'auth_outage'));
+        $mform->addElement('static', 'warningreenablemaintenancemode', '');
+
+        $this->add_action_buttons();
     }
 
     /**
@@ -145,6 +148,7 @@ class edit extends moodleform {
      */
     public function set_data($outage) {
         global $OUTPUT;
+        $mform = $this->_form;
 
         // Cannot change method signature, check type.
         if ($outage instanceof outage) {
@@ -158,21 +162,12 @@ class edit extends moodleform {
                 'description' => ['text' => $outage->description, 'format' => '1'],
             ]);
 
-            if (!empty($outage->id) && $outage->autostart && $outage->starttime < time() &&
-                    $outage->stoptime > time()) {
-                $this->_form->addElement('html',
-                    $OUTPUT->notification(get_string('warningreenablemaintenancemode', 'auth_outage'), 'notifywarning'));
+            if (!empty($outage->id) && $outage->autostart && $outage->starttime < time() && $outage->stoptime > time()) {
+                $warning = $mform->getElement('warningreenablemaintenancemode');
+                $warning->setValue($OUTPUT->notification(get_string('warningreenablemaintenancemode', 'auth_outage'), 'notifywarning'));
             }
         } else {
             throw new coding_exception('$outage must be an outage object.', $outage);
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     * @see moodleform::definition_after_data()
-     */
-    public function definition_after_data() {
-        $this->add_action_buttons();
     }
 }

--- a/classes/form/outage/edit.php
+++ b/classes/form/outage/edit.php
@@ -82,8 +82,6 @@ class edit extends moodleform {
         $mform->addHelpButton('description', 'description', 'auth_outage');
 
         $mform->addElement('static', 'usagehints', '', get_string('textplaceholdershint', 'auth_outage'));
-
-        $this->add_action_buttons();
     }
 
     /**
@@ -146,6 +144,8 @@ class edit extends moodleform {
      * @throws coding_exception
      */
     public function set_data($outage) {
+        global $OUTPUT;
+
         // Cannot change method signature, check type.
         if ($outage instanceof outage) {
             $this->_form->setDefaults([
@@ -157,6 +157,14 @@ class edit extends moodleform {
                 'title' => $outage->title,
                 'description' => ['text' => $outage->description, 'format' => '1'],
             ]);
+
+            if (!empty($outage->id) && $outage->autostart && $outage->starttime < time() &&
+                    $outage->stoptime > time()) {
+                $this->_form->addElement('html',
+                    $OUTPUT->notification(get_string('warningreenablemaintenancemode', 'auth_outage'), 'notifywarning'));
+            }
+
+            $this->add_action_buttons();
         } else {
             throw new coding_exception('$outage must be an outage object.', $outage);
         }

--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -163,16 +163,25 @@ class outagelib {
 
     /**
      * Executed when outages are modified (created, updated or deleted).
+     *
+     * @param bool $reenablemaint should we re-enable maintenance mode for ongoing outage
+     * @throws coding_exception
+     * @throws file_exception
      */
-    public static function prepare_next_outage() {
+    public static function prepare_next_outage($reenablemaint = false) {
         // If there is an ongoing outage, prepare it instead.
         $outage = outagedb::get_ongoing();
         if (is_null($outage)) {
             $outage = outagedb::get_next_starting();
+            $ongoingoutage = false;
+        } else {
+            $ongoingoutage = true;
         }
         maintenance_static_page::create_from_outage($outage)->generate();
         self::update_climaintenance_code($outage);
-        self::update_maintenance_later($outage);
+        if (!$ongoingoutage || $reenablemaint || is_null($outage)) {
+            self::update_maintenance_later($outage);
+        }
     }
 
     private static function check_wwwroot_accessible() {

--- a/edit.php
+++ b/edit.php
@@ -38,15 +38,11 @@ $PAGE->set_url(new moodle_url('/auth/outage/manage.php'));
 
 $mform = new edit();
 
-if ($mform->is_submitted()) {
-    $mform->is_validated();
-
-    if ($mform->is_cancelled()) {
-        redirect(new moodle_url('/auth/outage/manage.php'));
-    } else if ($outage = $mform->get_data()) {
-        $id = outagedb::save($outage);
-        redirect(new moodle_url('/auth/outage/manage.php'));
-    }
+if ($mform->is_cancelled()) {
+    redirect(new moodle_url('/auth/outage/manage.php'));
+} else if ($outage = $mform->get_data()) {
+    $id = outagedb::save($outage);
+    redirect(new moodle_url('/auth/outage/manage.php'));
 }
 
 $clone = optional_param('clone', 0, PARAM_INT);

--- a/edit.php
+++ b/edit.php
@@ -42,7 +42,7 @@ if ($mform->is_cancelled()) {
     redirect(new moodle_url('/auth/outage/manage.php'));
 } else if ($outage = $mform->get_data()) {
     $id = outagedb::save($outage);
-    redirect($CFG->wwwroot. '/auth/outage/manage.php#auth_outage_id_'.$id);
+    redirect(new moodle_url('/auth/outage/manage.php'));
 }
 
 $clone = optional_param('clone', 0, PARAM_INT);

--- a/edit.php
+++ b/edit.php
@@ -38,11 +38,15 @@ $PAGE->set_url(new moodle_url('/auth/outage/manage.php'));
 
 $mform = new edit();
 
-if ($mform->is_cancelled()) {
-    redirect(new moodle_url('/auth/outage/manage.php'));
-} else if ($outage = $mform->get_data()) {
-    $id = outagedb::save($outage);
-    redirect(new moodle_url('/auth/outage/manage.php'));
+if ($mform->is_submitted()) {
+    $mform->is_validated();
+
+    if ($mform->is_cancelled()) {
+        redirect(new moodle_url('/auth/outage/manage.php'));
+    } else if ($outage = $mform->get_data()) {
+        $id = outagedb::save($outage);
+        redirect(new moodle_url('/auth/outage/manage.php'));
+    }
 }
 
 $clone = optional_param('clone', 0, PARAM_INT);

--- a/lang/en/auth_outage.php
+++ b/lang/en/auth_outage.php
@@ -143,6 +143,7 @@ $string['title_help'] = 'A short title to for this outage. It will be displayed 
 $string['warningdurationerrorinvalid'] = 'Warning duration must be positive.';
 $string['warningduration'] = 'Warning duration';
 $string['warningduration_help'] = 'How long before the start of the outage should the warning be displayed.';
+$string['warningreenablemaintenancemode'] = 'Please note that saving this outage will re-enable maintenance mode.<br />Untick "Auto start maintenance mode" if you want to prevent this.';
 
 /*
  * Privacy provider (GDPR)

--- a/views/manage.php
+++ b/views/manage.php
@@ -30,6 +30,7 @@ use auth_outage\dml\outagedb;
 
 defined('MOODLE_INTERNAL') || die();
 
+global $OUTPUT;
 $urlnew = new moodle_url('/auth/outage/edit.php');
 
 echo $viewbag['warning'];
@@ -50,9 +51,7 @@ echo $viewbag['warning'];
     <?php endif; ?>
     <?php $outage = outagedb::get_ongoing(); ?>
     <?php if (is_null($outage)): ?>
-        <input type="button" class="form-submit"
-               value="<?php echo get_string('outagecreate', 'auth_outage'); ?>"
-               onclick="location.href='<?php echo $urlnew; ?>';"/>
+        <?php echo $OUTPUT->single_button($urlnew, get_string('outagecreate', 'auth_outage')); ?>
     <?php endif; ?>
 </section>
 

--- a/views/manage.php
+++ b/views/manage.php
@@ -26,6 +26,7 @@
 use auth_outage\output\manage\history_table;
 use auth_outage\output\manage\planned_table;
 use auth_outage\output\renderer;
+use auth_outage\dml\outagedb;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -47,9 +48,12 @@ echo $viewbag['warning'];
         $table->finish_output();
         ?>
     <?php endif; ?>
-    <input type="button" class="form-submit"
-           value="<?php echo get_string('outagecreate', 'auth_outage'); ?>"
-           onclick="location.href='<?php echo $urlnew; ?>';"/>
+    <?php $outage = outagedb::get_ongoing(); ?>
+    <?php if (is_null($outage)): ?>
+        <input type="button" class="form-submit"
+               value="<?php echo get_string('outagecreate', 'auth_outage'); ?>"
+               onclick="location.href='<?php echo $urlnew; ?>';"/>
+    <?php endif; ?>
 </section>
 
 <section id="section_outage_history">


### PR DESCRIPTION
This PR fixes #172 

* Show notification if user edits ongoing outage.
* Amend redirection url when outage is saved. `#auth_outage_id_'.$id` is not needed. If you create outage that starts now you're got redirected to http://your.moodle.com#auth_outage_id_666.
* Do not call `update_maintenance_later()` if you're deleting future outage or editing "Allowed IP list" setting and there is an ongoing outage.
* Hide "Create outage" button if there is an ongoing outage as it will cause re-enabling maintenance mode for ongoing outage. 
* Fix "Cancel button" on Edit form after it was moved from `definition()` method.