### PR TITLE
Do not run behat tests until moodle-plugin-ci is fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,4 +59,7 @@ script:
  - moodle-plugin-ci mustache
  - moodle-plugin-ci grunt
  - moodle-plugin-ci phpunit
- - moodle-plugin-ci behat
+# Behat tests are failing due to issue:
+# https://github.com/blackboard-open-source/moodle-plugin-ci/issues/70
+# Commenting it out until the issue is fixed.
+# - moodle-plugin-ci behat


### PR DESCRIPTION
This is a workaround for `moodle-plugin-ci` issue:
https://github.com/blackboard-open-source/moodle-plugin-ci/issues/70

`sudo: true`, `sudo: required` or
```
  apt:
    packages:
      - oracle-java8-installer
      - oracle-java8-set-default
```
couldn't help.