### PR TITLE
Fix Issue179

### DIFF
--- a/classes/local/controllers/maintenance_static_page_generator.php
+++ b/classes/local/controllers/maintenance_static_page_generator.php
@@ -139,6 +139,17 @@ class maintenance_static_page_generator {
     }
 
     /**
+     * Retrieves all URLs from file content using regular expressions.
+     *
+     * @param string $contents Content of the file
+     * @return array Array of all matches in multi-dimensional array
+     */
+    public function get_urls_from_stylesheet($contents) {
+        preg_match_all('#url\([\'"]?(?!data:)([^\'"\)]+)#', $contents, $matches);
+        return $matches;
+    }
+
+    /**
      * Checks for urls inside filename.
      *
      * @param string $filename
@@ -148,9 +159,8 @@ class maintenance_static_page_generator {
         global $CFG;
 
         $contents = file_get_contents($filename);
-        if (!preg_match_all('#url\([\'"]?(?!data:)([^\'"\)]+)#', $contents, $matches)) {
-            return;
-        }
+        $matches = $this->get_urls_from_stylesheet($contents);
+
         foreach ($matches[1] as $originalurl) {
             // Allow incomplete URLs in CSS, assume it is from moodle root.
             if (maintenance_static_page_io::is_url($originalurl)) {

--- a/classes/local/controllers/maintenance_static_page_generator.php
+++ b/classes/local/controllers/maintenance_static_page_generator.php
@@ -156,7 +156,25 @@ class maintenance_static_page_generator {
             if (maintenance_static_page_io::is_url($originalurl)) {
                 $fullurl = $originalurl;
             } else if ($originalurl[0] == '/') {
-                $fullurl = $CFG->wwwroot.$originalurl;
+                if (strpos($CFG->wwwroot, 'http://') === 0) {
+                    $domain = substr($CFG->wwwroot, 7);
+                    if (strpos($domain, '/') > 0) {
+                        $base = substr($domain, 0, strpos($domain, '/'));
+                    } else {
+                        $base = $domain;
+                    }
+                    $fullurl = 'http://'.$base.$originalurl;
+                } else if (strpos($CFG->wwwroot, 'https://') === 0) {
+                    $domain = substr($CFG->wwwroot, 8);
+                    if (strpos($domain, '/') > 0) {
+                        $base = substr($domain, 0, strpos($domain, '/'));
+                    } else {
+                        $base = $domain;
+                    }
+                    $fullurl = 'https://'.$base.$originalurl;
+                } else {
+                    $fullurl = $CFG->wwwroot.$originalurl;
+                }
             } else {
                 $fullurl = $baseref.'/'.$originalurl;
             }

--- a/classes/local/controllers/maintenance_static_page_generator.php
+++ b/classes/local/controllers/maintenance_static_page_generator.php
@@ -148,7 +148,7 @@ class maintenance_static_page_generator {
         global $CFG;
 
         $contents = file_get_contents($filename);
-        if (!preg_match_all('#url\([\'"]?([^\'"\)]+)#', $contents, $matches)) {
+        if (!preg_match_all('#url\([\'"]?(?!data:)([^\'"\)]+)#', $contents, $matches)) {
             return;
         }
         foreach ($matches[1] as $originalurl) {

--- a/classes/local/controllers/maintenance_static_page_generator.php
+++ b/classes/local/controllers/maintenance_static_page_generator.php
@@ -156,25 +156,8 @@ class maintenance_static_page_generator {
             if (maintenance_static_page_io::is_url($originalurl)) {
                 $fullurl = $originalurl;
             } else if ($originalurl[0] == '/') {
-                if (strpos($CFG->wwwroot, 'http://') === 0) {
-                    $domain = substr($CFG->wwwroot, 7);
-                    if (strpos($domain, '/') > 0) {
-                        $base = substr($domain, 0, strpos($domain, '/'));
-                    } else {
-                        $base = $domain;
-                    }
-                    $fullurl = 'http://'.$base.$originalurl;
-                } else if (strpos($CFG->wwwroot, 'https://') === 0) {
-                    $domain = substr($CFG->wwwroot, 8);
-                    if (strpos($domain, '/') > 0) {
-                        $base = substr($domain, 0, strpos($domain, '/'));
-                    } else {
-                        $base = $domain;
-                    }
-                    $fullurl = 'https://'.$base.$originalurl;
-                } else {
-                    $fullurl = $CFG->wwwroot.$originalurl;
-                }
+                $rooturl = parse_url($CFG->wwwroot);
+                $fullurl = $rooturl['scheme'].'://'.$rooturl['host'].$originalurl;
             } else {
                 $fullurl = $baseref.'/'.$originalurl;
             }

--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -64,7 +64,7 @@ class outagelib {
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5); // It is localhost, time to connect is enough.
-        curl_setopt($curl, CURLOPT_TIMEOUT, 15); // It is localhost, time to fetch index is enough.
+        curl_setopt($curl, CURLOPT_TIMEOUT, 60);
         $contents = curl_exec($curl);
         $mime = curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
         curl_close($curl);

--- a/tests/phpunit/local/controllers/fixtures/withurls-quoted.css
+++ b/tests/phpunit/local/controllers/fixtures/withurls-quoted.css
@@ -3,5 +3,5 @@ a {
 }
 
 div {
-    background-image: url('/auth/outage/tests/phpunit/local/controllers/fixtures/catalyst.png');
+    background-image: url('/moodle/auth/outage/tests/phpunit/local/controllers/fixtures/catalyst.png');
 }

--- a/tests/phpunit/local/controllers/fixtures/withurls.css
+++ b/tests/phpunit/local/controllers/fixtures/withurls.css
@@ -3,5 +3,5 @@ a {
 }
 
 div {
-    background-image: url(/auth/outage/tests/phpunit/local/controllers/fixtures/catalyst.png);
+    background-image: url(/moodle/auth/outage/tests/phpunit/local/controllers/fixtures/catalyst.png);
 }

--- a/tests/phpunit/local/controllers/maintenance_static_page_test.php
+++ b/tests/phpunit/local/controllers/maintenance_static_page_test.php
@@ -453,7 +453,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         $generator = new maintenance_static_page_generator(new DOMDocument(), new maintenance_static_page_io());
         $matches = $generator->get_urls_from_stylesheet($filecontent);
 
-        self::assertIsArray($matches);
+        self::assertInternalType('array', $matches);
         self::assertCount(2, $matches);
         self::assertCount($count, $matches[1]);
     }

--- a/tests/phpunit/local/controllers/maintenance_static_page_test.php
+++ b/tests/phpunit/local/controllers/maintenance_static_page_test.php
@@ -101,7 +101,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         $page->generate();
 
         // Check for css file.
-        self::assertFileExists($page->get_io()->get_resources_folder().'/622ef6e83acfcb274cdf37bdb3bffa0923f9a7ad.dGV4dC9wbGFpbg');
+        self::assertFileExists($page->get_io()->get_resources_folder().'/d8643101d96b093e642b15544e4d1f7815b5ba55.dGV4dC9wbGFpbg');
 
         // Check for catalyst.png file referenced in url(..) of css.
         self::assertFileExists($page->get_io()->get_resources_folder().'/ff7f7f87a26a908fc72930eaefb6b57306361d16.aW1hZ2UvcG5n');
@@ -116,7 +116,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         $page->generate();
 
         // Check for css file.
-        self::assertFileExists($page->get_io()->get_resources_folder().'/1d84b6d321fef780237f84834b7316c079221a31.dGV4dC9wbGFpbg');
+        self::assertFileExists($page->get_io()->get_resources_folder().'/9fe2374b03953e1949d54ab750be2d8706891c03.dGV4dC9wbGFpbg');
 
         // Check for catalyst.png file referenced in url(..) of css.
         self::assertFileExists($page->get_io()->get_resources_folder().'/ff7f7f87a26a908fc72930eaefb6b57306361d16.aW1hZ2UvcG5n');

--- a/tests/phpunit/local/controllers/maintenance_static_page_test.php
+++ b/tests/phpunit/local/controllers/maintenance_static_page_test.php
@@ -402,42 +402,22 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
      * @return array
      */
     public function test_get_urls_from_stylesheet_provider() {
-        $provider = array();
-
-        $filecontent = "";
-        $provider[] = array($filecontent, 0);
-
-        $filecontent = "background:url(/theme/image.php/_s/boost/core/1581292565/t/expanded)";
-        $provider[] = array($filecontent, 1);
-
-        $filecontent = "background:url('/theme/image.php/_s/boost/core/1581292565/t/expanded')";
-        $provider[] = array($filecontent, 1);
-
-        $filecontent = "src:url(\"/theme/font.php/boost/core/1581292565/fontawesome-webfont.eot?#iefix&v=4.7.0\")";
-        $provider[] = array($filecontent, 1);
-
-        $filecontent = "background-image:url(pix/vline-rtl.gif)";
-        $provider[] = array($filecontent, 1);
-
-        $filecontent = "background-image:url(data:image/gif;base64,R0lGODlhYADIAP=)";
-        $provider[] = array($filecontent, 0);
-
-        $filecontent = "background-image:url('data:image/gif;base64,R0lGODlhYADIAP=')";
-        $provider[] = array($filecontent, 0);
-
-        $filecontent = "background-image:url(\"data:image/svg+xml;charset=utf8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\'".
-            "viewBox=\'0 0 8 8\'%3E%3Cpath fill=\'%23fff\' d=\'M6.564.75l-3.59 2.193z\'/%3E%3C/svg%3E\")";
-        $provider[] = array($filecontent, 0);
-
-        $filecontent = "background-image:url(pix/vline-rtl.gif)".
-            "background:url(/theme/image.php/_s/boost/core/1581292565/t/expanded)";
-        $provider[] = array($filecontent, 2);
-
-        $filecontent = "background-image:url(data:image/gif;base64,R0lGODlhYADIAP=)".
-            "src:url(\"/theme/font.php/boost/core/1581292565/fontawesome-webfont.eot?#iefix&v=4.7.0\")";
-        $provider[] = array($filecontent, 1);
-
-        return $provider;
+        return [
+            // Empty string.
+            ["", 0],
+            // URLs that should be retrieved.
+            ["background:url(/theme/image.php/_s/boost/core/1581292565/t/expanded)", 1],
+            ["background:url('/theme/image.php/_s/boost/core/1581292565/t/expanded')", 1],
+            ["src:url(\"/theme/font.php/boost/core/1581292565/fontawesome-webfont.eot?#iefix&v=4.7.0\")", 1],
+            ["background-image:url(pix/vline-rtl.gif)", 1],
+            // URLs that should not be retrieved.
+            ["background-image:url(data:image/gif;base64,R0lGODlhYADIAP=)", 0],
+            ["background-image:url('data:image/gif;base64,R0lGODlhYADIAP=')", 0],
+            ["background-image:url(\"data:image/svg+xml;charset=utf8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\'\")", 0],
+            // Combination of URLs used above.
+            ["background-image:url(pix/vline-rtl.gif) background:url(/theme/image.php/_s/boost/core/158/t/expanded)", 2],
+            ["background-image:url(data:image/gif;base64,R0lG=)src:url(\"/theme/font.php/fontawesome-webfont.eot\")", 1],
+        ];
     }
 
     /**


### PR DESCRIPTION
This PR fixes issue #179 

* Increase timeout for cases when caches have been just purged. 15 sec not enough in this scenario and static page generation fails.
* Cook file url properly when Moodle is installed in a sub folder. Some files were trying to reach via url like `http://localhost/subdir/subdir/theme/styles.php`. Short url has already had subdir and then we concatenate it with `$CFG->wwwroot` that has subdir as well.
* Tweak regexp and exclude non-url entries. Entries like `url("data:image/svg+xml,%3csvg xmlns=\`:

![image](https://user-images.githubusercontent.com/22066290/73914408-5a809480-490d-11ea-8410-3d5860e16851.png)

* Update file hashes in unit tests.
* Move regexp to a separate method.
* Introduce unit tests for get_urls_from_stylesheet() method.
