### PR TITLE
Issue #189 Unable to find Class 'core\ip_utils'

### DIFF
--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -269,6 +269,7 @@ class outagelib {
 if ((time() >= {{STARTTIME}}) && (time() < {{STOPTIME}})) {
     define('MOODLE_INTERNAL', true);
     require_once($CFG->dirroot.'/lib/moodlelib.php');
+    require_once($CFG->dirroot.'/lib/classes/ip_utils.php');
     if (!remoteip_in_list('{{ALLOWEDIPS}}')) {
         header($_SERVER['SERVER_PROTOCOL'] . ' 503 Moodle under maintenance');
         header('Status: 503 Moodle under maintenance');


### PR DESCRIPTION
Following upgrade of moodle to 3.5.11, error above prevented moodle from
displaying on the web.  The class ip_utils was for somereason not loaded
and through an error preventing the site from displaying when in
maintenance mod.  Adding the require class appears to have fixed the
issue. #189 