### PR TITLE
Issue 189 Unable to find Class 'core\ip_utils'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ env:
 
 matrix:
   include:
-    - php: 5.5
+    - php: 5.6
       env: DB=pgsql MOODLE_BRANCH=MOODLE_30_STABLE
-    - php: 5.5
+    - php: 5.6
       env: DB=mysqli MOODLE_BRANCH=MOODLE_30_STABLE
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
     - $HOME/.composer/cache
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.5"
 
 php:
  - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ addons:
 php:
  - 7.0
 
+services:
+ - mysql
+
 env:
   - DB=pgsql MOODLE_BRANCH=MOODLE_30_STABLE
   - DB=pgsql MOODLE_BRANCH=MOODLE_31_STABLE

--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -253,6 +253,7 @@ class outagelib {
 if ((time() >= {{STARTTIME}}) && (time() < {{STOPTIME}})) {
     define('MOODLE_INTERNAL', true);
     require_once($CFG->dirroot.'/lib/moodlelib.php');
+    require_once($CFG->dirroot.'/lib/classes/ip_utils.php');
     if (!remoteip_in_list('{{ALLOWEDIPS}}')) {
         header($_SERVER['SERVER_PROTOCOL'] . ' 503 Moodle under maintenance');
         header('Status: 503 Moodle under maintenance');

--- a/tests/phpunit/local/outagelib_test.php
+++ b/tests/phpunit/local/outagelib_test.php
@@ -31,7 +31,7 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->libdir.'/adminlib.php');
-
+require_once(__DIR__.'/../base_testcase.php');
 /**
  * outagelib_test test class.
  *
@@ -293,6 +293,7 @@ class outagelib_test extends auth_outage_base_testcase {
 if ((time() >= 123) && (time() < 456)) {
     define('MOODLE_INTERNAL', true);
     require_once($CFG->dirroot.'/lib/moodlelib.php');
+    require_once($CFG->dirroot.'/lib/classes/ip_utils.php');
     if (!remoteip_in_list('heyyou
 a.b.c.d
 e.e.e.e/20')) {
@@ -333,6 +334,7 @@ EOT;
 if ((time() >= 123) && (time() < 456)) {
     define('MOODLE_INTERNAL', true);
     require_once($CFG->dirroot.'/lib/moodlelib.php');
+    require_once($CFG->dirroot.'/lib/classes/ip_utils.php');
     if (!remoteip_in_list('127.0.0.1')) {
         header($_SERVER['SERVER_PROTOCOL'] . ' 503 Moodle under maintenance');
         header('Status: 503 Moodle under maintenance');


### PR DESCRIPTION
Following upgrade of moodle to 3.5.11, error above prevented moodle from
displaying on the web.  The class ip_utils was for somereason not loaded
and through an error preventing the site from displaying when in
maintenance mod.  Adding the require class appears to have fixed the
issue.