### PR TITLE
WR #343135: Update tests to work with T12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 addons:
   firefox: "47.0.1"
-  postgresql: "9.5"
+  postgresql: "9.6"
   apt:
     packages:
     - openjdk-8-jre

--- a/tests/phpunit/base_testcase.php
+++ b/tests/phpunit/base_testcase.php
@@ -31,6 +31,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use auth_outage\dml\outagedb;
+
 defined('MOODLE_INTERNAL') || die();
 
 /**
@@ -69,5 +71,13 @@ abstract class auth_outage_base_testcase extends advanced_testcase {
 
         parent::setUp();
         $this->resetAfterTest(true);
+    }
+
+    public function tearDown() {
+        global $DB;
+
+        foreach (outagedb::get_all() as $i => $outage) {
+            $DB->delete_records('auth_outage', ['id' => $outage->id]);
+        }
     }
 }

--- a/tests/phpunit/local/outagelib_test.php
+++ b/tests/phpunit/local/outagelib_test.php
@@ -31,6 +31,7 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->libdir.'/adminlib.php');
+require_once(__DIR__.'/../base_testcase.php');
 
 /**
  * outagelib_test test class.
@@ -41,7 +42,7 @@ require_once($CFG->libdir.'/adminlib.php');
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @SuppressWarnings(public) Allow as many methods as needed.
  */
-class outagelib_test extends advanced_testcase {
+class outagelib_test extends auth_outage_base_testcase {
     /**
      * Check if maintenance message is disabled as needed.
      */


### PR DESCRIPTION
For some reason, $this->resetAfterTest(true); is not resetting the outage table in T12 (probably T11/13 too)

Adding an explicit tearDown to clean up the auth_outage table.

I did not use the outagelib::delete() function as it called calendar::delete() on outages that did not exist proper.