### PR TITLE
Remove all usage of $CFG->additionalhtmltopofbody #211

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -66,11 +66,4 @@ class auth_plugin_outage extends auth_plugin_base {
     public function user_login($username, $password) {
         return false;
     }
-
-    /**
-     * Login page hook.
-     */
-    public function loginpage_hook() {
-        outagelib::inject();
-    }
 }

--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -72,11 +72,10 @@ class outagelib {
     }
 
     /**
-     * Calls inject even if it was already called before.
+     * Resets inject called to allow the code to be regenerated.
      */
-    public static function reinject() {
+    public static function reset_injectcalled() {
         self::$injectcalled = false;
-        self::inject();
     }
 
     /**
@@ -100,19 +99,17 @@ class outagelib {
 
 
     /**
-     * Will check for ongoing or warning outages and will attach the message bar as required.
+     * Will check for ongoing or warning outages and will return the message bar as required.
+     *
+     * @return string|void CSS and HTML for the warning bar if it should be displayed
      */
-    public static function inject() {
-        global $CFG;
-
+    public static function get_inject_code() {
         // Ensure we do not kill the whole website in case of an error.
         try {
             // Check if we should inject the code.
             if (!self::injection_allowed()) {
                 return;
             }
-
-            self::clean_outages();
 
             // Check for a previewing outage, then for an active outage.
             $previewid = optional_param('auth_outage_preview', null, PARAM_INT);
@@ -136,8 +133,7 @@ class outagelib {
             }
 
             // There is a previewing or active outage.
-            $CFG->additionalhtmltopofbody = renderer::get()->render_warningbar($active, $time, false, $preview).
-                                            $CFG->additionalhtmltopofbody;
+            return renderer::get()->render_warningbar($active, $time, false, $preview);
         } catch (Exception $e) {
             debugging('Exception occured while injecting our code: '.$e->getMessage());
             debugging($e->getTraceAsString(), DEBUG_DEVELOPER);
@@ -396,27 +392,5 @@ EOT;
         }
 
         return $message;
-    }
-
-    /**
-     * Checks $CFG->additionalhtmltopofbody for saved outages and removes them.
-     * We should only be temporarily injecting into that variable and not saving them to the database.
-     *
-     * @return string the cleaned content
-     */
-    public static function clean_outages() {
-        global $CFG;
-
-        // Replace the content to clean up pages that do not have the injection.
-        $re = '/' . self::OUTAGE_START . '[\s\S]*' . self::OUTAGE_END . '/m';
-        $replaced = preg_replace($re, '', $CFG->additionalhtmltopofbody);
-
-        // We have removed the outages and any duplicates as it should be injected and not saved to $CFG.
-        if ($CFG->additionalhtmltopofbody != $replaced) {
-            set_config('additionalhtmltopofbody', $replaced);
-            return $replaced;
-        }
-
-        return '';
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -28,27 +28,6 @@ use auth_outage\local\outagelib;
 defined('MOODLE_INTERNAL') || die;
 
 /**
- * Used in Moodle 30+ when a user is logged on.
- */
-function auth_outage_extend_navigation_user_settings() {
-    outagelib::inject();
-}
-
-/**
- * Used in Moodle 30+ on the frontpage.
- */
-function auth_outage_extend_navigation_frontpage() {
-    outagelib::inject();
-}
-
-/**
- * Used in Moodle 31+ when a user is logged on.
- */
-function auth_outage_extend_navigation_user() {
-    outagelib::inject();
-}
-
-/**
  * Used for adminlib::set_updatedcallback which requires a string that resolves to a function.
  *
  * Related to: MDL-57264 and MDL-32984
@@ -97,4 +76,14 @@ function auth_outage_get_fontawesome_icon_map() {
     return [
         'core:i/auth_outageevent' => 'fa-power-off',
     ];
+}
+
+/**
+ * Inject the warning bar into the page if there is currently an outage.
+ *
+ * @return string|void
+ */
+function auth_outage_before_standard_top_of_body_html() {
+    // Get code to inject.
+    return outagelib::get_inject_code();
 }


### PR DESCRIPTION
Fix for #211

- Migrate injection logic into before_standard_top_of_body_html hook
- Removes old functions to inject HTML into navigation and clear $CFG->additionalhtmltopofbody
- Update tests so they no longer check $CFG->additionalhtmltopofbody