### PR TITLE
auth_outage: Update function calls to conform to PHPUnit 9 deprecations [Totara 13]

### DIFF
--- a/tests/phpunit/installation_test.php
+++ b/tests/phpunit/installation_test.php
@@ -72,7 +72,7 @@ class installation_test extends auth_outage_base_testcase {
         $progress = new progress_trace_buffer(new text_progress_trace(), false);
         core_plugin_manager::instance()->uninstall_plugin('auth_outage', $progress);
         $progress->finished();
-        self::assertContains('++ Success ++', $progress->get_buffer());
+        self::assertStringContainsString('++ Success ++', $progress->get_buffer());
 
         // Check ...
         self::assertSame(0, $DB->count_records_select('event', "eventtype = 'auth_outage'", null),

--- a/tests/phpunit/local/cli/cli_test.php
+++ b/tests/phpunit/local/cli/cli_test.php
@@ -82,8 +82,8 @@ class cli_test extends auth_outage_cli_testcase {
         $this->set_parameters(['-h']);
         $cli = new create();
         $output = $this->execute($cli);
-        self::assertContains('-h', $output);
-        self::assertContains('--help', $output);
+        self::assertStringContainsString('-h', $output);
+        self::assertStringContainsString('--help', $output);
     }
 
     /**

--- a/tests/phpunit/local/cli/create_test.php
+++ b/tests/phpunit/local/cli/create_test.php
@@ -121,8 +121,8 @@ class create_test extends auth_outage_cli_testcase {
         $this->set_parameters(['--help']);
         $cli = new create();
         $output = $this->execute($cli);
-        self::assertContains('Creates', $output);
-        self::assertContains('--help', $output);
+        self::assertStringContainsString('Creates', $output);
+        self::assertStringContainsString('--help', $output);
     }
 
     /**
@@ -158,7 +158,7 @@ class create_test extends auth_outage_cli_testcase {
         $cli = new create();
         $cli->set_referencetime($now);
         $text = $this->execute($cli);
-        self::assertContains('created', $text);
+        self::assertStringContainsString('created', $text);
         // Check creted outage.
         list(, $id) = explode(':', $text);
         $id = (int)$id;
@@ -222,7 +222,7 @@ class create_test extends auth_outage_cli_testcase {
             'description' => 'Default Description',
         ]);
         $text = $this->execute($cli);
-        self::assertContains('created', $text);
+        self::assertStringContainsString('created', $text);
         // Check creted outage.
         list(, $id) = explode(':', $text);
         $id = (int)$id;
@@ -300,8 +300,8 @@ class create_test extends auth_outage_cli_testcase {
         $cli = new create();
         $cli->set_referencetime($now);
         $text = $this->execute($cli);
-        self::assertContains('created', $text);
-        self::assertContains('started', $text);
+        self::assertStringContainsString('created', $text);
+        self::assertStringContainsString('started', $text);
     }
 
     /**

--- a/tests/phpunit/local/cli/finish_test.php
+++ b/tests/phpunit/local/cli/finish_test.php
@@ -73,8 +73,8 @@ class finish_test extends auth_outage_cli_testcase {
         $this->set_parameters(['--help']);
         $cli = new finish();
         $text = $this->execute($cli);
-        self::assertContains('Finishes', $text);
-        self::assertContains('--help', $text);
+        self::assertStringContainsString('Finishes', $text);
+        self::assertStringContainsString('--help', $text);
     }
 
     /**

--- a/tests/phpunit/local/cli/waitforit_test.php
+++ b/tests/phpunit/local/cli/waitforit_test.php
@@ -79,8 +79,8 @@ class waitforit_test extends auth_outage_cli_testcase {
         $this->set_parameters(['--help']);
         $cli = new waitforit();
         $text = $this->execute($cli);
-        self::assertContains('Waits', $text);
-        self::assertContains('--help', $text);
+        self::assertStringContainsString('Waits', $text);
+        self::assertStringContainsString('--help', $text);
     }
 
     /**
@@ -152,9 +152,9 @@ class waitforit_test extends auth_outage_cli_testcase {
         $cli = new waitforit();
         $cli->set_referencetime($now);
         $output = $this->execute($cli);
-        self::assertContains('Verbose mode', $output);
-        self::assertContains('starting in 1 sec', $output);
-        self::assertContains('started', $output);
+        self::assertStringContainsString('Verbose mode', $output);
+        self::assertStringContainsString('starting in 1 sec', $output);
+        self::assertStringContainsString('started', $output);
     }
 
     /**
@@ -179,11 +179,11 @@ class waitforit_test extends auth_outage_cli_testcase {
             return $now;
         });
         $output = $this->execute($cli);
-        self::assertContains("starting in 45", $output);
-        self::assertContains("sleep 30 second", $output);
-        self::assertContains("starting in 15", $output);
-        self::assertContains("sleep 15 second", $output);
-        self::assertContains("started!", $output);
+        self::assertStringContainsString("starting in 45", $output);
+        self::assertStringContainsString("sleep 30 second", $output);
+        self::assertStringContainsString("starting in 15", $output);
+        self::assertStringContainsString("sleep 15 second", $output);
+        self::assertStringContainsString("started!", $output);
     }
 
     /**

--- a/tests/phpunit/local/controllers/infopage_test.php
+++ b/tests/phpunit/local/controllers/infopage_test.php
@@ -104,7 +104,7 @@ class infopagecontroller_test extends auth_outage_base_testcase {
         ]);
         $info = new infopage(['outage' => $outage]);
         $output = $info->get_output();
-        self::assertContains('auth_outage_info', $output);
+        self::assertStringContainsString('auth_outage_info', $output);
     }
 
     /**

--- a/tests/phpunit/local/controllers/maintenance_static_page_test.php
+++ b/tests/phpunit/local/controllers/maintenance_static_page_test.php
@@ -77,7 +77,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         maintenance_static_page::create_from_html($html)->generate();
 
         $generated = $this->generated_page_html($html);
-        self::assertNotContains('<script', $generated);
+        self::assertStringNotContainsString('<script', $generated);
     }
 
     public function test_updatelinkstylesheet() {
@@ -89,7 +89,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         $generated = $this->generated_page_html($html);
 
         self::assertStringContainsString('www.example.com/moodle/auth/outage/file.php?file=', $generated);
-        self::assertNotContains($localcsslink, $generated);
+        self::assertStringNotContainsString($localcsslink, $generated);
         self::assertStringContainsString($externalcsslink, $generated);
     }
 
@@ -147,7 +147,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         $generated = $this->generated_page_html($html);
 
         self::assertStringContainsString('www.example.com/moodle/auth/outage/file.php?file=', $generated);
-        self::assertNotContains($localimglink, $generated);
+        self::assertStringNotContainsString($localimglink, $generated);
         self::assertStringContainsString($externalimglink, $generated);
     }
 
@@ -158,7 +158,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
                 '<body>Content</body></html>';
         $generated = $this->generated_page_html($html);
 
-        self::assertNotContains($link, $generated);
+        self::assertStringNotContainsString($link, $generated);
         self::assertStringContainsString('www.example.com/moodle/auth/outage/file.php?file=', $generated);
     }
 
@@ -172,7 +172,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         $page->generate();
         $generated = trim(file_get_contents($page->get_io()->get_template_file()));
 
-        self::assertNotContains($link, $generated);
+        self::assertStringNotContainsString($link, $generated);
         self::assertStringContainsString('www.example.com/moodle/auth/outage/file.php?file=preview%2F', $generated);
     }
 
@@ -295,8 +295,8 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         set_config('remove_selectors', '.removeme', 'auth_outage');
         $generated = $this->generated_page_html($html);
 
-        self::assertNotContains('removeme', $generated);
-        self::assertNotContains('Goodbye cruel world', $generated);
+        self::assertStringNotContainsString('removeme', $generated);
+        self::assertStringNotContainsString('Goodbye cruel world', $generated);
     }
 
     public function test_remove_css_selector_id() {
@@ -307,8 +307,8 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         set_config('remove_selectors', '#removeme', 'auth_outage');
         $generated = $this->generated_page_html($html);
 
-        self::assertNotContains('removeme', $generated);
-        self::assertNotContains('Goodbye cruel world', $generated);
+        self::assertStringNotContainsString('removeme', $generated);
+        self::assertStringNotContainsString('Goodbye cruel world', $generated);
     }
 
     public function test_remove_css_selector_with_multiline() {
@@ -322,9 +322,9 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         set_config('remove_selectors', ".removeme\n.deleteme", 'auth_outage');
         $generated = $this->generated_page_html($html);
 
-        self::assertNotContains('removeme', $generated);
-        self::assertNotContains('deleteme', $generated);
-        self::assertNotContains('Goodbye cruel world', $generated);
+        self::assertStringNotContainsString('removeme', $generated);
+        self::assertStringNotContainsString('deleteme', $generated);
+        self::assertStringNotContainsString('Goodbye cruel world', $generated);
     }
 
     public function test_remove_css_selector_needing_trim() {
@@ -338,9 +338,9 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         set_config('remove_selectors', " .removeme     \n    .deleteme   ", 'auth_outage');
         $generated = $this->generated_page_html($html);
 
-        self::assertNotContains('removeme', $generated);
-        self::assertNotContains('deleteme', $generated);
-        self::assertNotContains('Goodbye cruel world', $generated);
+        self::assertStringNotContainsString('removeme', $generated);
+        self::assertStringNotContainsString('deleteme', $generated);
+        self::assertStringNotContainsString('Goodbye cruel world', $generated);
     }
 
     public function test_remove_css_selector_with_empty_line() {
@@ -354,9 +354,9 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         set_config('remove_selectors', "\n\n.removeme\n\n\n\n.deleteme\n\n", 'auth_outage');
         $generated = $this->generated_page_html($html);
 
-        self::assertNotContains('removeme', $generated);
-        self::assertNotContains('deleteme', $generated);
-        self::assertNotContains('Goodbye cruel world', $generated);
+        self::assertStringNotContainsString('removeme', $generated);
+        self::assertStringNotContainsString('deleteme', $generated);
+        self::assertStringNotContainsString('Goodbye cruel world', $generated);
     }
 
     public function test_remove_css_selector_with_invalid_id() {

--- a/tests/phpunit/local/controllers/maintenance_static_page_test.php
+++ b/tests/phpunit/local/controllers/maintenance_static_page_test.php
@@ -88,9 +88,9 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
                 '<body>Content<link rel="stylesheet" href="'.$externalcsslink.'"></body></html>';
         $generated = $this->generated_page_html($html);
 
-        self::assertContains('www.example.com/moodle/auth/outage/file.php?file=', $generated);
+        self::assertStringContainsString('www.example.com/moodle/auth/outage/file.php?file=', $generated);
         self::assertNotContains($localcsslink, $generated);
-        self::assertContains($externalcsslink, $generated);
+        self::assertStringContainsString($externalcsslink, $generated);
     }
 
     public function test_updatelinkstylesheet_urls() {
@@ -146,9 +146,9 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
                 '<body><img src="'.$localimglink.'">Content<img src="'.$externalimglink.'" /></body></html>';
         $generated = $this->generated_page_html($html);
 
-        self::assertContains('www.example.com/moodle/auth/outage/file.php?file=', $generated);
+        self::assertStringContainsString('www.example.com/moodle/auth/outage/file.php?file=', $generated);
         self::assertNotContains($localimglink, $generated);
-        self::assertContains($externalimglink, $generated);
+        self::assertStringContainsString($externalimglink, $generated);
     }
 
     public function test_updatelinkfavicon() {
@@ -159,7 +159,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         $generated = $this->generated_page_html($html);
 
         self::assertNotContains($link, $generated);
-        self::assertContains('www.example.com/moodle/auth/outage/file.php?file=', $generated);
+        self::assertStringContainsString('www.example.com/moodle/auth/outage/file.php?file=', $generated);
     }
 
     public function test_previewpath() {
@@ -173,7 +173,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         $generated = trim(file_get_contents($page->get_io()->get_template_file()));
 
         self::assertNotContains($link, $generated);
-        self::assertContains('www.example.com/moodle/auth/outage/file.php?file=preview%2F', $generated);
+        self::assertStringContainsString('www.example.com/moodle/auth/outage/file.php?file=preview%2F', $generated);
     }
 
     /**
@@ -257,7 +257,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
 
     public function test_get_url_for_file() {
         $io = new maintenance_static_page_io();
-        self::assertContains('www.example.com/moodle/auth/outage/file.php?file=img.png', $io->get_url_for_file('img.png'));
+        self::assertStringContainsString('www.example.com/moodle/auth/outage/file.php?file=img.png', $io->get_url_for_file('img.png'));
     }
 
     public function test_is_url() {
@@ -367,8 +367,8 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         set_config('remove_selectors', '#invalidid', 'auth_outage');
         $generated = $this->generated_page_html($html);
 
-        self::assertContains('removeme', $generated);
-        self::assertContains('Goodbye cruel world', $generated);
+        self::assertStringContainsString('removeme', $generated);
+        self::assertStringContainsString('Goodbye cruel world', $generated);
     }
 
     public function test_meta_refresh_5minutes() {
@@ -379,7 +379,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         set_config('remove_selectors', '#invalidid', 'auth_outage');
         $generated = $this->generated_page_html($html);
 
-        self::assertContains('<meta http-equiv="refresh" content="300">', $generated);
+        self::assertStringContainsString('<meta http-equiv="refresh" content="300">', $generated);
     }
 
     public function test_meta_refresh_maximum_5seconds() {
@@ -394,7 +394,7 @@ class maintenance_static_page_test extends auth_outage_base_testcase {
         $generated = trim(file_get_contents($page->get_io()->get_template_file()));
         return $generated;
 
-        self::assertContains('<meta http-equiv="refresh" content="5">', $generated);
+        self::assertStringContainsString('<meta http-equiv="refresh" content="5">', $generated);
     }
 
     /**

--- a/tests/phpunit/local/outage_test.php
+++ b/tests/phpunit/local/outage_test.php
@@ -281,11 +281,11 @@ class outage_test extends auth_outage_base_testcase {
             'description' => 'Description {{start}} {{stop}} {{duration}}',
         ]);
         $title = $outage->get_title();
-        self::assertNotContains('{', $title);
-        self::assertNotContains('}', $title);
+        self::assertStringNotContainsString('{', $title);
+        self::assertStringNotContainsString('}', $title);
         $description = $outage->get_description();
-        self::assertNotContains('{', $description);
-        self::assertNotContains('}', $description);
+        self::assertStringNotContainsString('{', $description);
+        self::assertStringNotContainsString('}', $description);
     }
 
     /**

--- a/tests/phpunit/local/outagelib_test.php
+++ b/tests/phpunit/local/outagelib_test.php
@@ -99,8 +99,8 @@ class outagelib_test extends auth_outage_base_testcase {
 
         outagelib::reset_injectcalled();
         $header1 = outagelib::get_inject_code();
-        self::assertContains('<style>', $header1);
-        self::assertContains('<script>', $header1);
+        self::assertStringContainsString('<style>', $header1);
+        self::assertStringContainsString('<script>', $header1);
 
         // Should not inject more than once.
         $size = strlen($OUTPUT->standard_top_of_body_html());
@@ -140,8 +140,8 @@ class outagelib_test extends auth_outage_base_testcase {
 
         outagelib::reset_injectcalled();
         $header = outagelib::get_inject_code();
-        self::assertContains('<style>', $header);
-        self::assertContains('<script>', $header);
+        self::assertStringContainsString('<style>', $header);
+        self::assertStringContainsString('<script>', $header);
     }
 
     /**


### PR DESCRIPTION
* assertContains() is deprecated, and replaced by assertStringContainsString() in PHPUnit 9, and Totara 13 issues warnings in relation to this
