### PR TITLE
Issue#271: Fix refactored phpunit_util causing unit test error

### DIFF
--- a/tests/phpunit/calendar/calendar_test.php
+++ b/tests/phpunit/calendar/calendar_test.php
@@ -134,8 +134,8 @@ class auth_outage_calendar_test extends advanced_testcase {
         ]);
 
         calendar::update($outage);
-        self::assertCount(1, phpunit_util::get_debugging_messages());
-        phpunit_util::reset_debugging();
+        self::assertCount(1, $this->getDebuggingMessages());
+        $this->resetDebugging();
     }
 
     /**
@@ -146,8 +146,8 @@ class auth_outage_calendar_test extends advanced_testcase {
         self::setAdminUser();
 
         calendar::delete(1);
-        self::assertCount(1, phpunit_util::get_debugging_messages());
-        phpunit_util::reset_debugging();
+        self::assertCount(1, $this->getDebuggingMessages());
+        $this->resetDebugging();
     }
 
     /**

--- a/tests/phpunit/dml/outagedb_test.php
+++ b/tests/phpunit/dml/outagedb_test.php
@@ -427,8 +427,8 @@ class auth_outage_outagedb_test extends auth_outage_base_testcase {
     public function test_finish_now_notfound() {
         $this->resetAfterTest(true);
         outagedb::finish(1);
-        self::assertCount(1, phpunit_util::get_debugging_messages());
-        phpunit_util::reset_debugging();
+        self::assertCount(1, $this->getDebuggingMessages());
+        $this->resetDebugging();
     }
 
     /**
@@ -449,8 +449,8 @@ class auth_outage_outagedb_test extends auth_outage_base_testcase {
         self::assertTrue(!$outage->is_ongoing($time));
 
         outagedb::finish($id, $time);
-        self::assertCount(1, phpunit_util::get_debugging_messages());
-        phpunit_util::reset_debugging();
+        self::assertCount(1, $this->getDebuggingMessages());
+        $this->resetDebugging();
     }
 
     /**

--- a/tests/phpunit/form/forms_test.php
+++ b/tests/phpunit/form/forms_test.php
@@ -146,8 +146,8 @@ class auth_outage_forms_test extends auth_outage_base_testcase {
         $_POST['description'] = ['text' => 'The <b>description</b>.', 'format' => '2'];
         $edit = new edit();
         self::assertNull($edit->get_data());
-        self::assertCount(1, phpunit_util::get_debugging_messages());
-        phpunit_util::reset_debugging();
+        self::assertCount(1, $this->getDebuggingMessages());
+        $this->resetDebugging();
     }
 
     /**

--- a/tests/phpunit/local/controllers/maintenance_static_page_test.php
+++ b/tests/phpunit/local/controllers/maintenance_static_page_test.php
@@ -401,8 +401,8 @@ class auth_outage_maintenance_static_page_test extends auth_outage_base_testcase
         $found = maintenance_static_page_io::file_get_data(__DIR__.'/fixtures/invalidfile');
         self::assertSame('', $found['contents']);
         self::assertSame('unknown', $found['mime']);
-        self::assertCount(1, phpunit_util::get_debugging_messages());
-        phpunit_util::reset_debugging();
+        self::assertCount(1, $this->getDebuggingMessages());
+        $this->resetDebugging();
     }
 
     /**

--- a/tests/phpunit/local/outagelib_test.php
+++ b/tests/phpunit/local/outagelib_test.php
@@ -62,8 +62,8 @@ class auth_outage_outagelib_test extends auth_outage_base_testcase {
         set_config('maintenance_message', 'A message.');
         outagedb::save($outage);
         self::assertFalse((bool)get_config('moodle', 'maintenance_message'));
-        self::assertCount(2, phpunit_util::get_debugging_messages());
-        phpunit_util::reset_debugging();
+        self::assertCount(2, $this->getDebuggingMessages());
+        $this->resetDebugging();
     }
 
     /**
@@ -116,8 +116,8 @@ class auth_outage_outagelib_test extends auth_outage_base_testcase {
         $_GET = ['auth_outage_break_code' => '1'];
         outagelib::reset_injectcalled();
         $header = outagelib::get_inject_code();
-        self::assertCount(2, phpunit_util::get_debugging_messages());
-        phpunit_util::reset_debugging();
+        self::assertCount(2, $this->getDebuggingMessages());
+        $this->resetDebugging();
     }
 
     /**


### PR DESCRIPTION
substitute in platform-agnostic functions ->getDebuggingMessages and ->resetDebugging