### PR TITLE
Slow down warning bar checkfinished calls

### DIFF
--- a/views/warningbar/warningbar.js
+++ b/views/warningbar/warningbar.js
@@ -78,13 +78,8 @@ var authOutageWarningBar = {
         xmlhttp.open("GET", this.checkfinishedurl, true);
         xmlhttp.send();
 
-        var estimatedServerTime = this.servertime + (Date.now() - this.clienttime);
-        var sleepSeconds = this.stops - estimatedServerTime; // How long to sleep until it stops.
-        if (sleepSeconds <= 0) {
-            sleepSeconds = 5; // It should be back, keep checking every 5 seconds.
-        } else {
-            sleepSeconds = Math.min(sleepSeconds, (5 * 60)); // Check at least every 5 minutes.
-        }
+        // Check if site is back online every 5 minutes with some random margin.
+        var sleepSeconds = 4 * 60 + Math.random() * 120;
 
         setTimeout(function() {
             $this.tickOngoing();

--- a/views/warningbar/warningbar.js
+++ b/views/warningbar/warningbar.js
@@ -56,6 +56,8 @@ var authOutageWarningBar = {
     },
 
     tickOngoing: function() {
+        const MINSECS = 60;
+
         if (this.finished) {
             return;
         }
@@ -78,8 +80,8 @@ var authOutageWarningBar = {
         xmlhttp.open("GET", this.checkfinishedurl, true);
         xmlhttp.send();
 
-        // Check if site is back online every 5 minutes with some random margin.
-        var sleepSeconds = 4 * 60 + Math.random() * 120;
+        // Checking if the site is back online every 4-6 minutes.
+        var sleepSeconds = 4 * MINSECS + (2 * MINSECS * Math.random());
 
         setTimeout(function() {
             $this.tickOngoing();


### PR DESCRIPTION
This is a fix for issue 279.

`4 * 60 + Math.random() * 120` gives random duration between 4 and 6 mins. This is to make sure that user browsers won't send their AJAX requests at the same time.