### PR TITLE
replace deprecated strftime function for Moodle 4.2

### DIFF
--- a/classes/local/cli/waitforit.php
+++ b/classes/local/cli/waitforit.php
@@ -129,7 +129,7 @@ class waitforit extends clibase {
             return;
         }
 
-        $time = strftime('%F %T %Z');
+        $time = \core_date::strftime('%F %T %Z');
         printf("[%s] %s\n", $time, $message);
     }
 


### PR DESCRIPTION
Core Moodle 4.2 replacement for strftime function deprecated in php 8.1