### PR TITLE
replace deprecated strftime function for Tōtara 17

### DIFF
--- a/classes/local/cli/waitforit.php
+++ b/classes/local/cli/waitforit.php
@@ -129,7 +129,7 @@ class waitforit extends clibase {
             return;
         }
 
-        $time = strftime('%F %T %Z');
+        $time = \totara_core\strftime::format('%F %T %Z');
         printf("[%s] %s\n", $time, $message);
     }
 


### PR DESCRIPTION
Core Tōtara 17 replacement for strftime function deprecated in php 8.1