### PR TITLE
Change hook callback to string #336

### DIFF
--- a/db/hooks.php
+++ b/db/hooks.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 $callbacks = [
     [
         'hook' => \core\hook\output\before_standard_top_of_body_html_generation::class,
-        'callback' => [\auth_outage\hook_callbacks::class, 'before_standard_top_of_body_html_generation'],
+        'callback' => '\auth_outage\hook_callbacks::before_standard_top_of_body_html_generation',
         'priority' => 0,
     ],
 ];

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = "auth_outage";
-$plugin->version = 2024052000;                  // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release = 2024052000;                  // Human-readable release information.
+$plugin->version = 2024052400;                  // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release = 2024052400;                  // Human-readable release information.
 $plugin->requires = 2017111309;                 // 2017111309 = T13, but this really requires 3.9 and higher.
 $plugin->maturity = MATURITY_STABLE;            // Suitable for PRODUCTION environments!
 $plugin->supported = [39, 404];                 // A range of branch numbers of supported moodle versions.


### PR DESCRIPTION
Changes the new hook callback back to a string for greater compatibility as it was causing some issues in 4.3

Closes #336 