### PR TITLE
cleanup: fixup to match coding standards

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * This file should run before config.php requires '/lib/setup.php'.
  *

--- a/classes/calendar/calendar.php
+++ b/classes/calendar/calendar.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * calendar class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\calendar;
 
 use auth_outage\local\outage;

--- a/classes/dml/outagedb.php
+++ b/classes/dml/outagedb.php
@@ -14,18 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * outagedb class.
- *
- * The DB Context to manipulate Outages.
- * It will also commit changes to the calendar as you change outages.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\dml;
 
 use auth_outage\calendar\calendar;

--- a/classes/event/outage_created.php
+++ b/classes/event/outage_created.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Toutage_created class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\event;
 
 use core\event\base;

--- a/classes/event/outage_deleted.php
+++ b/classes/event/outage_deleted.php
@@ -14,14 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * outage_deleted class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
 namespace auth_outage\event;
 
 use core\event\base;

--- a/classes/event/outage_updated.php
+++ b/classes/event/outage_updated.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * outage_updated class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\event;
 
 use core\event\base;

--- a/classes/form/outage/delete.php
+++ b/classes/form/outage/delete.php
@@ -14,22 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * delete class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\form\outage;
 
 defined('MOODLE_INTERNAL') || die();
-
 require_once($CFG->libdir.'/formslib.php');
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * delete class.

--- a/classes/form/outage/edit.php
+++ b/classes/form/outage/edit.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * edit class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\form\outage;
 
 use auth_outage\local\outage;
@@ -166,7 +157,7 @@ class edit extends moodleform {
             if (array_key_exists('auth_outage', $CFG->forced_plugin_settings)
                 && array_key_exists('default_autostart', $CFG->forced_plugin_settings['auth_outage'])) {
                 $this->_form->setDefaults([
-                    'autostart' => $CFG->forced_plugin_settings['auth_outage']['default_autostart']
+                    'autostart' => $CFG->forced_plugin_settings['auth_outage']['default_autostart'],
                 ]);
                 $mform->freeze('autostart');
             }

--- a/classes/form/outage/finish.php
+++ b/classes/form/outage/finish.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * finish class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\form\outage;
 
 use moodleform;

--- a/classes/local/cli/cli_exception.php
+++ b/classes/local/cli/cli_exception.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * cli_exception class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local\cli;
 
 use Exception;
@@ -85,9 +76,9 @@ class cli_exception extends Exception {
      * cliexception constructor.
      * @param string $message An explanation of the exception.
      * @param int $code Exit code to be used.
-     * @param Exception $previous Another exception as reference or null.
+     * @param Exception|null $previous Another exception as reference or null.
      */
-    public function __construct($message, $code = 1, Exception $previous = null) {
+    public function __construct($message, $code = 1, ?Exception $previous = null) {
         parent::__construct('*ERROR* '.$message, $code, $previous = null);
     }
 }

--- a/classes/local/cli/clibase.php
+++ b/classes/local/cli/clibase.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * clibase class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local\cli;
 
 use auth_outage\local\outagelib;
@@ -50,10 +41,10 @@ abstract class clibase {
 
     /**
      * clibase constructor.
-     * @param array $options The parameters to use.
+     * @param array|null $options The parameters to use.
      * @throws cli_exception
      */
-    public function __construct(array $options = null) {
+    public function __construct(?array $options = null) {
         global $CFG;
         require_once($CFG->libdir.'/clilib.php');
 

--- a/classes/local/cli/create.php
+++ b/classes/local/cli/create.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * create class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local\cli;
 
 use auth_outage\dml\outagedb;

--- a/classes/local/cli/finish.php
+++ b/classes/local/cli/finish.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * finish class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local\cli;
 
 use auth_outage\dml\outagedb;

--- a/classes/local/cli/waitforit.php
+++ b/classes/local/cli/waitforit.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * waitforit class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local\cli;
 
 use auth_outage\dml\outagedb;

--- a/classes/local/controllers/infopage.php
+++ b/classes/local/controllers/infopage.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * infopage class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local\controllers;
 
 use auth_outage\dml\outagedb;
@@ -53,9 +44,9 @@ class infopage {
 
     /**
      * infopage_controller constructor.
-     * @param array $params Parameters to use or null to get from Moodle API (request).
+     * @param array|null $params Parameters to use or null to get from Moodle API (request).
      */
-    public function __construct(array $params = null) {
+    public function __construct(?array $params = null) {
         global $CFG;
         // Enable SVG support here to make sure all SVG files
         // used in the current theme are served properly.

--- a/classes/local/controllers/maintenance_static_page.php
+++ b/classes/local/controllers/maintenance_static_page.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * maintenance_static_page class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local\controllers;
 
 use auth_outage\local\outage;

--- a/classes/local/controllers/maintenance_static_page_generator.php
+++ b/classes/local/controllers/maintenance_static_page_generator.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * maintenance_static_page_generator class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local\controllers;
 
 use auth_outage\local\outagelib;

--- a/classes/local/controllers/maintenance_static_page_io.php
+++ b/classes/local/controllers/maintenance_static_page_io.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * maintenance_static_page_io class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local\controllers;
 
 use auth_outage\local\outagelib;

--- a/classes/local/outage.php
+++ b/classes/local/outage.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * outage class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local;
 
 use coding_exception;

--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -14,20 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * outagelib class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local;
 
 use auth_outage\dml\outagedb;
 use auth_outage\local\controllers\maintenance_static_page;
-use auth_outage\output\renderer;
 use coding_exception;
 use curl;
 use Exception;
@@ -36,7 +26,6 @@ use invalid_parameter_exception;
 use stdClass;
 
 defined('MOODLE_INTERNAL') || die();
-
 require_once(__DIR__.'/../../lib.php');
 
 /**

--- a/classes/output/manage/base_table.php
+++ b/classes/output/manage/base_table.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * base_table class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <danielroperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\output\manage;
 
 use auth_outage\local\outage;
@@ -31,7 +22,6 @@ use html_writer;
 use moodle_url;
 
 defined('MOODLE_INTERNAL') || die();
-
 require_once($CFG->libdir.'/tablelib.php');
 
 /**

--- a/classes/output/manage/history_table.php
+++ b/classes/output/manage/history_table.php
@@ -14,21 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * history_table class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <danielroperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\output\manage;
 
 use auth_outage\local\outage;
 
 defined('MOODLE_INTERNAL') || die();
-
 require_once($CFG->libdir.'/tablelib.php');
 
 /**

--- a/classes/output/manage/planned_table.php
+++ b/classes/output/manage/planned_table.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * planned_table class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <danielroperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\output\manage;
 
 use auth_outage\local\outage;
@@ -30,7 +21,6 @@ use html_writer;
 use moodle_url;
 
 defined('MOODLE_INTERNAL') || die();
-
 require_once($CFG->libdir.'/tablelib.php');
 
 /**

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * auth_outage_renderer class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\output;
 
 use auth_outage\local\outage;

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -13,20 +13,14 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace auth_outage\privacy;
+
 /**
  * Privacy Subsystem implementation for auth_outage.
  *
  * @package    auth_outage
  * @copyright  2018 Olivier SECRET <olivier.secret@catalyst-au.net>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-namespace auth_outage\privacy;
-
-/**
- * Privacy provider for the authentication manual.
- *
- * @copyright  2018 Carlos Escobedo <carlos@moodle.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider implements
@@ -41,7 +35,7 @@ class provider implements
      *
      * @return  string
      */
-    public static function get_reason() : string {
+    public static function get_reason(): string {
         return 'privacy:no_data_reason';
     }
 

--- a/classes/task/update_static_page.php
+++ b/classes/task/update_static_page.php
@@ -14,18 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * update_static_page class.
- *
- * @package   auth_outage
- * @author    Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright 2016 Catalyst IT
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\task;
 
-use auth_outage\local\controllers\infopage;
 use auth_outage\local\outagelib;
 use core\task\scheduled_task;
 

--- a/db/access.php
+++ b/db/access.php
@@ -26,12 +26,12 @@
 defined('MOODLE_INTERNAL') || die();
 
 $capabilities = [
-    'auth/outage:viewinfo' => array(
+    'auth/outage:viewinfo' => [
         'captype' => 'read',
         'contextlevel' => CONTEXT_SYSTEM,
-        'archetypes' => array(
+        'archetypes' => [
             'guest' => CAP_ALLOW,
             'user' => CAP_ALLOW,
-        )
-    ),
+        ],
+    ],
 ];

--- a/tests/base_testcase.php
+++ b/tests/base_testcase.php
@@ -14,6 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace auth_outage;
+
+use auth_outage\dml\outagedb;
+use auth_outage\local\outage;
+
 /**
  * Base testcase for auth outage tests.
  *
@@ -24,20 +29,6 @@
  * Moodle 32 (as of now) uses PHPUnit 5.4.8 which deprecated setExpectedException().
  * In PHPUnit 6 the setExpectedException() will be removed.
  * We are not not using the annotation expectException as it is not accepted by Moodle Checker.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-namespace auth_outage;
-
-use auth_outage\dml\outagedb;
-use auth_outage\local\outage;
-
-/**
- * base_testcase class.
  *
  * @package    auth_outage
  * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
@@ -72,7 +63,7 @@ abstract class base_testcase extends \advanced_testcase {
     protected function revoke_info_page_permissions() {
         global $DB;
 
-        $guestrole = $DB->get_record('role', array('shortname' => 'guest'));
+        $guestrole = $DB->get_record('role', ['shortname' => 'guest']);
         role_change_permission($guestrole->id, \context_system::instance(), 'auth/outage:viewinfo', CAP_PREVENT);
 
         $this->setGuestUser();

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * tests for lib.php
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2017 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage;
 
 defined('MOODLE_INTERNAL') || die();

--- a/tests/local/controllers/maintenance_static_page_test.php
+++ b/tests/local/controllers/maintenance_static_page_test.php
@@ -199,26 +199,27 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      * Data provider for test_update_inline_background_images
      * @return array
      */
-    public function test_update_inline_background_images_provider() {
+    public static function update_inline_background_images_provider(): array {
         return [
             // Empty string.
             ["", false],
             // URLs that should be retrieved.
             ["color: #FF00FF; background: lightblue url(/pluginfile.php/1/theme_custom/banner/251298630/0001.png) no-repeat", true],
-            ["background: lightblue url(https://www.example.com/moodle/pluginfile.php/1/theme_custom/banner/251298630/0001.png) no-repeat", true],
+            ["background: lightblue
+                url(https://www.example.com/moodle/pluginfile.php/1/theme_custom/banner/251298630/0001.png) no-repeat", true],
             ["background:url('https://www.example.com/moodle/pluginfile.php/1/theme_custom/banner/251298630/0001.png')", true],
             ["background-image : url( /pix/help.png);", true],
             ["background-image: url ('/pix/help.png')", true],
             // URLs that should not be retrieved.
             ["background-image:url(data:image/gif;base64,R0lGODlhYADIAP=)", false],
-            ["background-image:url('data:image/gif;base64,R0lGODlhYADIAP=')", false]
+            ["background-image:url('data:image/gif;base64,R0lGODlhYADIAP=')", false],
         ];
     }
 
     /**
      * Tests update_inline_background_images() method to update the background images.
      *
-     * @dataProvider test_update_inline_background_images_provider
+     * @dataProvider update_inline_background_images_provider
      * @param string $stylecontent Content of the style to test
      * @param bool $rewrite Flag if URL should be rewritten
      * @throws coding_exception
@@ -372,14 +373,14 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
     /**
      * Return array of url data provider and true or false.
      */
-    public function is_url_dataprovider() {
+    public static function is_url_dataprovider(): array {
         return [
             [true, 'http://catalyst.net.nz'],
             [true, 'https://www.catalyst-au.net/'],
             [false, '/homepage'],
             [false, 'file://homepage'],
             [true, '//catalyst-au.net/img/test.jpg'],
-            [false, '://www.catalyst-au.net/img/test.jpg']
+            [false, '://www.catalyst-au.net/img/test.jpg'],
         ];
     }
 
@@ -560,7 +561,7 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      * Data provider for test_get_urls_from_stylesheet
      * @return array
      */
-    public function test_get_urls_from_stylesheet_provider() {
+    public static function get_urls_from_stylesheet_provider(): array {
         return [
             // Empty string.
             ["", 0],
@@ -582,7 +583,7 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
     /**
      * Tests get_urls_from_stylesheet() method to get all appropriate URLS from the file.
      *
-     * @dataProvider test_get_urls_from_stylesheet_provider
+     * @dataProvider get_urls_from_stylesheet_provider
      * @param string $filecontent Content of the file
      * @param int $count Expected quantity of found URLs
      * @throws coding_exception

--- a/tests/local/outage_test.php
+++ b/tests/local/outage_test.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * outage_test test class.
- *
- * @package    auth_outage
- * @author     Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright  2016 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local;
 
 defined('MOODLE_INTERNAL') || die();

--- a/tests/local/outagelib_test.php
+++ b/tests/local/outagelib_test.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * outagelib_test test class.
- *
- * @package     auth_outage
- * @author      Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
- * @copyright   2016 Catalyst IT
- * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace auth_outage\local;
 
 use auth_outage\dml\outagedb;
@@ -361,7 +352,7 @@ EOT;
      * Test create maintenance php code without age
      *
      * @param string $configkey The key of the config.
-     * @dataProvider test_createmaintenancephpcode_withoutage_provider
+     * @dataProvider createmaintenancephpcode_withoutage_provider
      */
     public function test_createmaintenancephpcode_withoutage($configkey) {
         global $CFG;
@@ -414,7 +405,11 @@ EOT;
         self::assertSame($found, $expected);
     }
 
-    public function test_createmaintenancephpcode_withoutage_provider(): array {
+    /**
+     * Provides values to test_createmaintenancephpcode_withoutage
+     * @return array
+     */
+    public static function createmaintenancephpcode_withoutage_provider(): array {
         return [['allowedips'], ['allowedips_forced']];
     }
 

--- a/views/info/content.php
+++ b/views/info/content.php
@@ -24,6 +24,7 @@
  *
  * @var array $viewbag
  */
+// phpcs:disable moodle.Commenting.MissingDocblock.File
 
 defined('MOODLE_INTERNAL') || die();
 ?>

--- a/views/manage.php
+++ b/views/manage.php
@@ -22,6 +22,7 @@
  * @copyright  2016 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+// phpcs:disable moodle.Commenting.MissingDocblock.File
 
 use auth_outage\output\manage\history_table;
 use auth_outage\output\manage\planned_table;

--- a/views/warningbar/warningbar.php
+++ b/views/warningbar/warningbar.php
@@ -22,6 +22,7 @@
  * @copyright  2016 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+// phpcs:disable moodle.Commenting.MissingDocblock.File
 
 use auth_outage\local\outagelib;
 


### PR DESCRIPTION
This plugin is pretty old so lots of this that used to be ok but now needs to be cleaned up.

**Changes**
- Ran `phpcbf` to fix lots of auto fixable errors
- Manually fixed unit test data providers - naming + static
- Added a few coding standards ignores for the (admittedly not standard moodle) view pages - they were breaking because of the multiple `<?php` inside the page.
- Phpcs was warning about implicitly null values that weren't typed as such (php 8.4 compatibility). Since this branch is 7.2+ according to docs and nullable parameters were added in 7.1 this is good to be fixed.
- Removed the duplicated class docblocks
- Removed an unnecessary `defined('MOODLE_INTERNAL') || die()`