### PR TITLE
Fix: make access key and allowed ips OR conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Note: these restrictions build on each other; If both are enabled, users must me
 Only allow users from a certain IP or range of ips to enter.
 ## Access key
 Users provide an access key in the URL params on first page load, which is then stored as a cookie for 24 hours. If the access key matches the one setup for the outage, they are allowed in.
+## Using IP restriction with access key
+Users will be allowed if they are from the configured allowed ips OR if they provide the correct access key.
 
 
 Feedback and issues

--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -321,10 +321,10 @@ if ((time() >= {{STARTTIME}}) && (time() < {{STOPTIME}})) {
 
     $ipblocked = !remoteip_in_list('{{ALLOWEDIPS}}');
     $accesskeyblocked = $useraccesskey != '{{ACCESSKEY}}';
-    $blocked = ({{USEACCESSKEY}} && $accesskeyblocked) || ({{USEALLOWEDIPS}} && $ipblocked);
+    $allowed = ({{USEACCESSKEY}} && !$accesskeyblocked) || ({{USEALLOWEDIPS}} && !$ipblocked);
     $isphpunit = defined('PHPUNIT_TEST');
 
-    if ($blocked) {
+    if (!$allowed) {
         if (!$isphpunit) {
             header($_SERVER['SERVER_PROTOCOL'] . ' 503 Moodle under maintenance');
             header('Status: 503 Moodle under maintenance');
@@ -347,17 +347,9 @@ if ((time() >= {{STARTTIME}}) && (time() < {{STOPTIME}})) {
         if ({{USEALLOWEDIPS}} && $ipblocked) {
             echo '<!-- Blocked by ip, your ip: '.getremoteaddr('n/a').' -->';
         }
-        
-        if ({{USEALLOWEDIPS}} && !$ipblocked) {
-            echo '<!-- Your IP is allowed: '.getremoteaddr('n/a').' -->';
-        }
 
         if ({{USEACCESSKEY}} && $accesskeyblocked) {
             echo '<!-- Blocked by missing or incorrect access key, access key given: '. $useraccesskey .' -->';
-        }
-
-        if ({{USEACCESSKEY}} && !$accesskeyblocked) {
-            echo '<!-- Your access key is allowed: '. $useraccesskey .' -->';
         }
 
         if (!$isphpunit) {

--- a/tests/local/outagelib_test.php
+++ b/tests/local/outagelib_test.php
@@ -335,10 +335,10 @@ if ((time() >= 123) && (time() < 456)) {
 a.b.c.d
 e.e.e.e/20');
     $accesskeyblocked = $useraccesskey != '12345';
-    $blocked = (true && $accesskeyblocked) || (true && $ipblocked);
+    $allowed = (true && !$accesskeyblocked) || (true && !$ipblocked);
     $isphpunit = defined('PHPUNIT_TEST');
 
-    if ($blocked) {
+    if (!$allowed) {
         if (!$isphpunit) {
             header($_SERVER['SERVER_PROTOCOL'] . ' 503 Moodle under maintenance');
             header('Status: 503 Moodle under maintenance');
@@ -361,17 +361,9 @@ e.e.e.e/20');
         if (true && $ipblocked) {
             echo '<!-- Blocked by ip, your ip: '.getremoteaddr('n/a').' -->';
         }
-        
-        if (true && !$ipblocked) {
-            echo '<!-- Your IP is allowed: '.getremoteaddr('n/a').' -->';
-        }
 
         if (true && $accesskeyblocked) {
             echo '<!-- Blocked by missing or incorrect access key, access key given: '. $useraccesskey .' -->';
-        }
-
-        if (true && !$accesskeyblocked) {
-            echo '<!-- Your access key is allowed: '. $useraccesskey .' -->';
         }
 
         if (!$isphpunit) {
@@ -422,10 +414,10 @@ if ((time() >= 123) && (time() < 456)) {
 
     $ipblocked = !remoteip_in_list('127.0.0.1');
     $accesskeyblocked = $useraccesskey != '5678';
-    $blocked = (true && $accesskeyblocked) || (true && $ipblocked);
+    $allowed = (true && !$accesskeyblocked) || (true && !$ipblocked);
     $isphpunit = defined('PHPUNIT_TEST');
 
-    if ($blocked) {
+    if (!$allowed) {
         if (!$isphpunit) {
             header($_SERVER['SERVER_PROTOCOL'] . ' 503 Moodle under maintenance');
             header('Status: 503 Moodle under maintenance');
@@ -448,17 +440,9 @@ if ((time() >= 123) && (time() < 456)) {
         if (true && $ipblocked) {
             echo '<!-- Blocked by ip, your ip: '.getremoteaddr('n/a').' -->';
         }
-        
-        if (true && !$ipblocked) {
-            echo '<!-- Your IP is allowed: '.getremoteaddr('n/a').' -->';
-        }
 
         if (true && $accesskeyblocked) {
             echo '<!-- Blocked by missing or incorrect access key, access key given: '. $useraccesskey .' -->';
-        }
-
-        if (true && !$accesskeyblocked) {
-            echo '<!-- Your access key is allowed: '. $useraccesskey .' -->';
         }
 
         if (!$isphpunit) {
@@ -679,12 +663,11 @@ EOT;
      * @return array
      */
     public static function evaluation_maintenancepage_provider(): array {
-        $allowedipout = '<!-- Your IP is allowed:';
         $blockedipout = '<!-- Blocked by ip, your ip:';
-        $allowedaccesskeyout = '<!-- Your access key is allowed:';
         $blockedaccesskeyout = '<!-- Blocked by missing or incorrect access key, access key given:';
 
         return [
+            // IP set up, access key not set up.
             'ip allowed, no access key setup' => [
                 'allowedips' => '127.0.0.1',
                 'iptouse' => '127.0.0.1',
@@ -699,6 +682,7 @@ EOT;
                 'accesskeytouse' => null,
                 'expectedoutputs' => [$blockedipout],
             ],
+            // IP not set up, access key set up.
             'access key incorrect, no ip setup' => [
                 'allowedips' => null,
                 'iptouse' => null,
@@ -713,19 +697,27 @@ EOT;
                 'accesskeytouse' => '12345',
                 'expectedoutputs' => [],
             ],
+            // Both IP and access key set up.
+            'access key incorrect, ip incorrect' => [
+                'allowedips' => '127.0.0.1',
+                'iptouse' => '5.5.5.5',
+                'accesskey' => '12345',
+                'accesskeytouse' => 'wrong',
+                'expectedoutputs' => [$blockedipout, $blockedaccesskeyout],
+            ],
             'access key correct, ip incorrect' => [
                 'allowedips' => '127.0.0.1',
                 'iptouse' => '5.5.5.5',
                 'accesskey' => '12345',
                 'accesskeytouse' => '12345',
-                'expectedoutputs' => [$allowedaccesskeyout, $blockedipout],
+                'expectedoutputs' => [],
             ],
             'access key incorrect, ip correct' => [
                 'allowedips' => '127.0.0.1',
                 'iptouse' => '127.0.0.1',
                 'accesskey' => '12345',
                 'accesskeytouse' => 'wrong',
-                'expectedoutputs' => [$blockedaccesskeyout, $allowedipout],
+                'expectedoutputs' => [],
             ],
             'access key correct, ip correct' => [
                 'allowedips' => '127.0.0.1',


### PR DESCRIPTION
Access keys and allowed IPs should be indpendant of each other and when at least one of them is satisfied the user should be allowed in.

The implementation of https://github.com/catalyst/moodle-auth_outage/issues/340 made it if both access key and allowed IP was used if one of them failed the user was blocked. The correct use case was allowed IP was still to be used but an access key could be used so someone outside of that IP range could still get in with the provided key.

**Test plan**
| Test | Expected | Result |
|--------|--------|--------|
|  No access key setup, no IP range setup |  Not blocked ever | ✅ Not blocked  |
|  Access key setup, no IP range setup. Access key incorrect | Blocked | ✅ Blocked  |
| Access key setup, no IP range setup. Access key correct |  Not blocked | ✅ Not blocked  | 
| No Access key setup, IP range setup. Inside of IP range. |  Not blocked |  ✅ Not blocked | 
| No Access key setup, IP range setup. Outside of IP range. |  Blocked | ✅  Blocked | 
| Access key setup and IP range setup. Inside of IP range, access key incorrect |  Not blocked |  ✅ Not blocked | 
| Access key setup and IP range setup. Outside of IP range, access key correct |  Not blocked |  ✅ Not blocked | 
| Access key setup and IP range setup. Inside of IP range, access key correct |  Not blocked |  ✅  Not blocked |
| Access key setup and IP range setup. Outside of IP range, access key incorrect |  Blocked | ✅ Blocked |