### PR TITLE
Fix #350: Do not setcookie during unit tests

### DIFF
--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -311,8 +311,9 @@ if ((time() >= {{STARTTIME}}) && (time() < {{STOPTIME}})) {
     }
     // Put access key as a cookie if given. This stops the need to put it as a url param on every request.
     $urlaccesskey = optional_param('accesskey', null, PARAM_TEXT);
+    $isphpunit = defined('PHPUNIT_TEST');
 
-    if (!empty($urlaccesskey)) {
+    if (!empty($urlaccesskey) && !$isphpunit) {
         setcookie('auth_outage_accesskey', $urlaccesskey, time() + 86400, '/', '', {{COOKIESECURE}}, {{COOKIEHTTPONLY}});
     }
 
@@ -322,7 +323,6 @@ if ((time() >= {{STARTTIME}}) && (time() < {{STOPTIME}})) {
     $ipblocked = !remoteip_in_list('{{ALLOWEDIPS}}');
     $accesskeyblocked = $useraccesskey != '{{ACCESSKEY}}';
     $allowed = ({{USEACCESSKEY}} && !$accesskeyblocked) || ({{USEALLOWEDIPS}} && !$ipblocked);
-    $isphpunit = defined('PHPUNIT_TEST');
 
     if (!$allowed) {
         if (!$isphpunit) {

--- a/tests/local/outagelib_test.php
+++ b/tests/local/outagelib_test.php
@@ -323,8 +323,9 @@ if ((time() >= 123) && (time() < 456)) {
     }
     // Put access key as a cookie if given. This stops the need to put it as a url param on every request.
     $urlaccesskey = optional_param('accesskey', null, PARAM_TEXT);
+    $isphpunit = defined('PHPUNIT_TEST');
 
-    if (!empty($urlaccesskey)) {
+    if (!empty($urlaccesskey) && !$isphpunit) {
         setcookie('auth_outage_accesskey', $urlaccesskey, time() + 86400, '/', '', true, false);
     }
 
@@ -336,7 +337,6 @@ a.b.c.d
 e.e.e.e/20');
     $accesskeyblocked = $useraccesskey != '12345';
     $allowed = (true && !$accesskeyblocked) || (true && !$ipblocked);
-    $isphpunit = defined('PHPUNIT_TEST');
 
     if (!$allowed) {
         if (!$isphpunit) {
@@ -404,8 +404,9 @@ if ((time() >= 123) && (time() < 456)) {
     }
     // Put access key as a cookie if given. This stops the need to put it as a url param on every request.
     $urlaccesskey = optional_param('accesskey', null, PARAM_TEXT);
+    $isphpunit = defined('PHPUNIT_TEST');
 
-    if (!empty($urlaccesskey)) {
+    if (!empty($urlaccesskey) && !$isphpunit) {
         setcookie('auth_outage_accesskey', $urlaccesskey, time() + 86400, '/', '', true, false);
     }
 
@@ -415,7 +416,6 @@ if ((time() >= 123) && (time() < 456)) {
     $ipblocked = !remoteip_in_list('127.0.0.1');
     $accesskeyblocked = $useraccesskey != '5678';
     $allowed = (true && !$accesskeyblocked) || (true && !$ipblocked);
-    $isphpunit = defined('PHPUNIT_TEST');
 
     if (!$allowed) {
         if (!$isphpunit) {


### PR DESCRIPTION
**Description:** This resolves issue #350. These errors were occurring because we executing `setcookie`. This does not need to be done when running unit tests.

> Cookies are part of the HTTP header, so [setcookie()](https://www.php.net/manual/en/function.setcookie.php) must be called before any output is sent to the browser

https://www.php.net/manual/en/features.cookies.php