### PR TITLE
Revert "Issue #358: Added some extra styling for outage icons"

### DIFF
--- a/classes/output/manage/base_table.php
+++ b/classes/output/manage/base_table.php
@@ -81,7 +81,7 @@ class base_table extends flexible_table {
                 'src' => $OUTPUT->image_url('t/preview'),
                 'alt' => get_string('view'),
                 'class' => 'iconsmall',
-                'style' => 'width: 1.5rem; height: 1.5rem;',
+
             ]),
             [
                 'title' => get_string('view'),
@@ -97,7 +97,6 @@ class base_table extends flexible_table {
                     'src' => $OUTPUT->image_url('t/edit'),
                     'alt' => get_string('edit'),
                     'class' => 'iconsmall',
-                    'style' => 'width: 1.5rem; height: 1.5rem;',
                 ]),
                 ['title' => get_string('edit')]
             );
@@ -110,7 +109,6 @@ class base_table extends flexible_table {
                 'src' => $OUTPUT->image_url('t/copy'),
                 'alt' => get_string('clone', 'auth_outage'),
                 'class' => 'iconsmall',
-                'style' => 'width: 1.5rem; height: 1.5rem;',
 
             ]),
             ['title' => get_string('clone', 'auth_outage')]
@@ -124,7 +122,6 @@ class base_table extends flexible_table {
                     'src' => $OUTPUT->image_url('t/check'),
                     'alt' => get_string('finish', 'auth_outage'),
                     'class' => 'iconsmall',
-                    'style' => 'width: 1.5rem; height: 1.5rem;',
                 ]),
                 ['title' => get_string('finish', 'auth_outage')]
             );
@@ -138,7 +135,6 @@ class base_table extends flexible_table {
                     'src' => $OUTPUT->image_url('t/delete'),
                     'alt' => get_string('delete'),
                     'class' => 'iconsmall',
-                    'style' => 'width: 1.5rem; height: 1.5rem;',
                 ]),
                 ['title' => get_string('delete')]
             );

--- a/views/warningbar/warningbar.php
+++ b/views/warningbar/warningbar.php
@@ -52,7 +52,6 @@ if (!$viewbag['static']) {
                 'src' => $OUTPUT->image_url('t/check'),
                 'alt' => get_string('finish', 'auth_outage'),
                 'class' => 'iconsmall',
-                'style' => 'width: 1rem; height: 1rem;',
             ]).' '.get_string('finish', 'auth_outage');
         $attr = [
             'title' => get_string('finish', 'auth_outage'),


### PR DESCRIPTION
**Description:** Revert catalyst/moodle-auth_outage#359. The changes affect the icon sizes when used in previous Moodle versions:

**Before commit:**

![image](https://github.com/user-attachments/assets/8651b804-3700-4aee-974c-ed4ca94601b5)


**After commit (in both 3.9 and 4.1):**
![image](https://github.com/user-attachments/assets/ff3bae0d-2b72-456b-ad54-d9f6696be898)


