### PR TITLE
Issue #358: Use pix_icon to render icons

### DIFF
--- a/classes/output/manage/base_table.php
+++ b/classes/output/manage/base_table.php
@@ -77,12 +77,7 @@ class base_table extends flexible_table {
         // View button.
         $buttons .= html_writer::link(
             new moodle_url('/auth/outage/info.php', ['id' => $outage->id]),
-            html_writer::empty_tag('img', [
-                'src' => $OUTPUT->image_url('t/preview'),
-                'alt' => get_string('view'),
-                'class' => 'iconsmall',
-                'style' => 'width: 1.5rem; height: 1.5rem;',
-            ]),
+            $OUTPUT->pix_icon('t/preview', get_string('view'), 'moodle', array('class' => 'iconsmall')),
             [
                 'title' => get_string('view'),
                 'target' => '_blank',
@@ -93,12 +88,7 @@ class base_table extends flexible_table {
         if ($editdelete) {
             $buttons .= html_writer::link(
                 new moodle_url('/auth/outage/edit.php', ['edit' => $outage->id]),
-                html_writer::empty_tag('img', [
-                    'src' => $OUTPUT->image_url('t/edit'),
-                    'alt' => get_string('edit'),
-                    'class' => 'iconsmall',
-                    'style' => 'width: 1.5rem; height: 1.5rem;',
-                ]),
+                $OUTPUT->pix_icon('t/edit', get_string('edit'), 'moodle', array('class' => 'iconsmall')),
                 ['title' => get_string('edit')]
             );
         }
@@ -106,13 +96,7 @@ class base_table extends flexible_table {
         // Clone button.
         $buttons .= html_writer::link(
             new moodle_url('/auth/outage/edit.php', ['clone' => $outage->id]),
-            html_writer::empty_tag('img', [
-                'src' => $OUTPUT->image_url('t/copy'),
-                'alt' => get_string('clone', 'auth_outage'),
-                'class' => 'iconsmall',
-                'style' => 'width: 1.5rem; height: 1.5rem;',
-
-            ]),
+            $OUTPUT->pix_icon('t/copy', get_string('clone', 'auth_outage'), 'moodle', array('class' => 'iconsmall')),
             ['title' => get_string('clone', 'auth_outage')]
         );
 
@@ -120,12 +104,7 @@ class base_table extends flexible_table {
         if ($outage->is_ongoing()) {
             $buttons .= html_writer::link(
                 new moodle_url('/auth/outage/finish.php', ['id' => $outage->id]),
-                html_writer::empty_tag('img', [
-                    'src' => $OUTPUT->image_url('t/check'),
-                    'alt' => get_string('finish', 'auth_outage'),
-                    'class' => 'iconsmall',
-                    'style' => 'width: 1.5rem; height: 1.5rem;',
-                ]),
+                $OUTPUT->pix_icon('t/check', get_string('finish', 'auth_outage'), 'moodle', array('class' => 'iconsmall')),
                 ['title' => get_string('finish', 'auth_outage')]
             );
         }
@@ -134,12 +113,7 @@ class base_table extends flexible_table {
         if ($editdelete) {
             $buttons .= html_writer::link(
                 new moodle_url('/auth/outage/delete.php', ['id' => $outage->id]),
-                html_writer::empty_tag('img', [
-                    'src' => $OUTPUT->image_url('t/delete'),
-                    'alt' => get_string('delete'),
-                    'class' => 'iconsmall',
-                    'style' => 'width: 1.5rem; height: 1.5rem;',
-                ]),
+                $OUTPUT->pix_icon('t/delete', get_string('delete'), 'moodle', array('class' => 'iconsmall')),
                 ['title' => get_string('delete')]
             );
         }

--- a/views/warningbar/warningbar.php
+++ b/views/warningbar/warningbar.php
@@ -47,18 +47,15 @@ if (!$viewbag['static']) {
         ['target' => '_blank', 'class' => 'auth_outage_warningbar_box_title']
     );
     if (is_siteadmin()) {
-        $url = new moodle_url('/auth/outage/finish.php', ['id' => $viewbag['outage']->id]);
-        $text = html_writer::empty_tag('img', [
-                'src' => $OUTPUT->image_url('t/check'),
-                'alt' => get_string('finish', 'auth_outage'),
-                'class' => 'iconsmall',
-                'style' => 'width: 1rem; height: 1rem;',
-            ]).' '.get_string('finish', 'auth_outage');
-        $attr = [
-            'title' => get_string('finish', 'auth_outage'),
-            'class' => 'auth_outage_warningbar_box_finish',
-        ];
-        $title .= ' '.html_writer::span(html_writer::link($url, $text, $attr), '', ['id' => 'auth_outage_warningbar_button']);
+        $link = html_writer::link(
+            new moodle_url('/auth/outage/finish.php', ['id' => $viewbag['outage']->id]),
+            $OUTPUT->pix_icon('t/check', get_string('finish', 'auth_outage'), 'moodle', array('class' => 'iconsmall')) . get_string('finish', 'auth_outage'),
+            [
+                'title' => get_string('finish', 'auth_outage'),
+                'class' => 'auth_outage_warningbar_box_finish',
+            ]
+        );
+        $title .= ' '.html_writer::span($link, '', ['id' => 'auth_outage_warningbar_button']);
     }
 }
 ?>


### PR DESCRIPTION
**Description:** This resolves Issue #358 (and fixes subsequent regressions, see https://github.com/catalyst/moodle-auth_outage/pull/360) by using `pix_icon` instead of `html_writer::empty_tag`. This simplifies the code by using the core methods of rendering icons.

This fixes the original issue in MWP 4.5 and causes no regressions when used in older versions (tested Moodle 3.9, Moodle 4.1, Moodle 4.5, MWP 4.5 and Totara 13)

