### PR TITLE
Fix URL is blocked message when not behind a proxy/load balancer

### DIFF
--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -57,7 +57,7 @@ class outagelib {
         global $CFG;
         require_once($CFG->libdir . '/filelib.php');
 
-        $curl = new curl();
+        $curl = new curl(['ignoresecurity' => true]);
         $contents = $curl->get($file);
         $info = $curl->get_info();
         if (!empty($info['content_type'])) {

--- a/tests/local/controllers/maintenance_static_page_test.php
+++ b/tests/local/controllers/maintenance_static_page_test.php
@@ -424,6 +424,37 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
     }
 
     /**
+     * Test file_get_data with curlsecurityblockedhosts.
+     * We will use an external URL to test passing ignoresecurity inside of file_get_data works,
+     * ideally in real code we should only be calling file_get_data with internal URLs.
+     */
+    public function test_file_get_data_curlsecurityblockedhosts() {
+        global $CFG, $USER;
+
+        $testhtml = $this->getExternalTestFileUrl('/test.html');
+        $url = new \moodle_url($testhtml);
+        $host = $url->get_host();
+        set_config('curlsecurityblockedhosts', $host); // Blocks $host.
+
+        // Test a regular curl with the default security enabled does in fact get blocked.
+        $curl = new \curl();
+        $contents = $curl->get($testhtml);
+        $expected = $curl->get_security()->get_blocked_url_string();
+        self::assertSame($expected, $contents);
+        self::assertSame(0, $curl->get_errno());
+        if ($CFG->branch >= 403) {
+            self::assertDebuggingCalled(
+                "Blocked $testhtml: The URL is blocked. [user {$USER->id}]", DEBUG_NONE);
+        }
+
+        // Test file_get_data does return the page and isn't blocked by security.
+        $found = maintenance_static_page_io::file_get_data($url->out());
+        $expected = '47250a973d1b88d9445f94db4ef2c97a';
+        self::assertSame($expected, md5($found['contents']));
+        self::assertSame('text/html', $found['mime']);
+    }
+
+    /**
      * Test remove css selector.
      */
     public function test_remove_css_selector() {


### PR DESCRIPTION
When there is no proxy/load balancer and curlsecurityblockedhosts is set to default (i.e. has 127.0.0.1 in it) fetching the outage page will result in a "The URL is blocked." message. This resolves that issue by passing ignoresecurity to the curl object.

Using ignoresecurity should be safe as we will only ever be curling internal pages and not out to the internet.

To test this if you are using docker dev and are behind nginx, the quickest way to test is to;
- `control web site`
- Ping your local URL and note down the IP returned
- Add that IP to $CFG->curlsecurityblockedhosts