### PR TITLE
[T19] Replace deprecated testcase classes with core_phpunit

### DIFF
--- a/tests/base_testcase.php
+++ b/tests/base_testcase.php
@@ -35,7 +35,7 @@ use auth_outage\local\outage;
  * @copyright  2016 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-abstract class base_testcase extends \advanced_testcase {
+abstract class base_testcase extends \core_phpunit\testcase {
     /**
      * Checks PHPUnit version and calls the functions accordingly.
      * @param string $exception Expected exception class.

--- a/tests/calendar/calendar_test.php
+++ b/tests/calendar/calendar_test.php
@@ -39,7 +39,7 @@ use auth_outage\local\outage;
  * @license         http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @covers          \auth_outage\calendar\calendar
  */
-class calendar_test extends \advanced_testcase {
+class calendar_test extends \core_phpunit\testcase {
     /**
      * @var outage|null The calendar entry owner.
      */

--- a/tests/dml/events_test.php
+++ b/tests/dml/events_test.php
@@ -39,7 +39,7 @@ use auth_outage\local\outage;
  * @license         http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @covers          \auth_outage\dml\outagedb
  */
-class events_test extends \advanced_testcase {
+class events_test extends \core_phpunit\testcase {
     /**
      * @var outage|null Outage used in the tests.
      */


### PR DESCRIPTION
Adds fix so unit tests can run with Tōtara 19.

I created this MR against the branch currently used for Tōtara 13+ sites but it'll likely need a new TOTARA_19 branch.