### PR TITLE
outagelib: adjust exception trigger for phpunit10

### DIFF
--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -266,7 +266,9 @@ class outagelib {
 
         // Used to test the try block in case of errors.
         if (PHPUNIT_TEST && optional_param('auth_outage_break_code', false, PARAM_INT)) {
-            (new stdClass())->invalidfield; // Triggers an exception.
+            if (!isset($emptyvar)) {
+                throw new coding_exception('Empty variable "emptyvar" is empty');
+            }
         }
 
         // Nothing preventing the injection.

--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -266,9 +266,7 @@ class outagelib {
 
         // Used to test the try block in case of errors.
         if (PHPUNIT_TEST && optional_param('auth_outage_break_code', false, PARAM_INT)) {
-            if (!isset($emptyvar)) {
-                throw new coding_exception('Empty variable "emptyvar" is empty');
-            }
+            throw new coding_exception('Exception triggered');
         }
 
         // Nothing preventing the injection.


### PR DESCRIPTION
phpunit 10+ has shifted the way it deals with php exceptions so outagelib_test::test_inject_broken no longer triggers debugging.
This can be addressed by adjusting the deliberate exception to be explicitly thrown, rather than triggered by php infraction.