### PR TITLE
[#368] Ensure output buffer is empty before serving files

### DIFF
--- a/file.php
+++ b/file.php
@@ -69,6 +69,11 @@ function auth_outage_bootstrap_callback() {
         http_response_code(404);
         die('File not found.');
     }
+
+    // Ensure there is nothing in the output buffer.
+    // otherwise the file will not be read correctly.
+    ob_clean();
+
     readfile($file);
     exit(0);
 }


### PR DESCRIPTION
Closes #368 

**Changes**

- Clean the output buffer to remove any debugging messages or other garbage that ended up there before sending file.

**Testing**

Manual testing:
- Before: Images on outage page (served from `/auth/outage/file.php`) would give error "Image cannot be displayed due to errors"
- After: Images shown correctly