### PR TITLE
Fix #314: Switch optional_param starttime to optional_param_array

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -49,6 +49,19 @@ if ($mform->is_cancelled()) {
 $clone = optional_param('clone', 0, PARAM_INT);
 $edit = optional_param('edit', 0, PARAM_INT);
 $start = optional_param_array('starttime', [], PARAM_INT);
+if (!empty($start['year']) && !empty($start['month']) && !empty($start['day'])) {
+    $hour = $start['hour'] ?? 0;
+    $minute = $start['minute'] ?? 0;
+    $time = make_timestamp(
+        (int) $start['year'],
+        (int) $start['month'],
+        (int) $start['day'],
+        (int) $hour,
+        (int) $minute
+    );
+} else {
+    $time = 0;
+}
 if ($clone && $edit) {
     throw new invalid_parameter_exception('Cannot provide both clone and edit ids.');
 }

--- a/edit.php
+++ b/edit.php
@@ -48,7 +48,11 @@ if ($mform->is_cancelled()) {
 
 $clone = optional_param('clone', 0, PARAM_INT);
 $edit = optional_param('edit', 0, PARAM_INT);
-$start = optional_param_array('starttime', [], PARAM_INT);
+if (array_key_exists('starttime', $_POST) && is_array($_POST['starttime'])) {
+    $start = optional_param_array('starttime', [], PARAM_INT);
+} else {
+    $start = optional_param('starttime', 0, PARAM_INT);
+}
 if (!empty($start['year']) && !empty($start['month']) && !empty($start['day'])) {
     $hour = $start['hour'] ?? 0;
     $minute = $start['minute'] ?? 0;

--- a/edit.php
+++ b/edit.php
@@ -48,7 +48,7 @@ if ($mform->is_cancelled()) {
 
 $clone = optional_param('clone', 0, PARAM_INT);
 $edit = optional_param('edit', 0, PARAM_INT);
-$time = optional_param('starttime', 0, PARAM_INT);
+$start = optional_param_array('starttime', [], PARAM_INT);
 if ($clone && $edit) {
     throw new invalid_parameter_exception('Cannot provide both clone and edit ids.');
 }


### PR DESCRIPTION
Fix #314 

When warning duration is set to 0, the form fails the validation and return no data https://github.com/catalyst/moodle-auth_outage/blob/MOODLE_501_STABLE/edit.php#L44 

The params starttime comes back as an array of integer. Hence why the error get trigger.
