### PR TITLE
Issue #390: Code cleanup to fix code standards codesniffer errors.

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -32,7 +32,7 @@ use auth_outage\local\outagelib;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir.'/authlib.php');
+require_once($CFG->libdir . '/authlib.php');
 
 /**
  * auth_plugin_outage class.

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -29,11 +29,10 @@
  *
  * @var stdClass $CFG
  */
+define('MOODLE_INTERNAL', true);
 
-if (!defined('MOODLE_INTERNAL')) {
-    define('MOODLE_INTERNAL', true);
-}
-defined('MOODLE_INTERNAL') || die();  // Make sniffer happy.
+defined('MOODLE_INTERNAL') || die();
+
 //
 // We need the CFG->dataroot, if not set yet this script is called too early in config.php file.
 if (!isset($CFG->dataroot)) {
@@ -42,7 +41,7 @@ if (!isset($CFG->dataroot)) {
 
 // 1) Make sure we replace the configurations for behat as we have not ran 'lib/setup.php' yet.
 if (!empty($CFG->behat_wwwroot) || !empty($CFG->behat_dataroot) || !empty($CFG->behat_prefix)) {
-    require_once(__DIR__.'/../../lib/behat/lib.php');
+    require_once(__DIR__ . '/../../lib/behat/lib.php');
     behat_update_vars_for_process();
     if (behat_is_test_site()) {
         $beforebehatcfg = $CFG;
@@ -76,11 +75,11 @@ if (!empty($_SERVER['REQUEST_URI'])) {
     if (array_key_exists('path', $rooturl) && !empty($rooturl['path'])) {
         $path = $rooturl['path'];
     }
-    $url = $path.'/auth/outage/info.php';
+    $url = $path . '/auth/outage/info.php';
     $outageinfo = strpos($_SERVER['REQUEST_URI'], $url) === 0 ? true : false;
 }
 
-$allowed = !file_exists($CFG->dataroot.'/climaintenance.php') // Not in maintenance mode.
+$allowed = !file_exists($CFG->dataroot . '/climaintenance.php') // Not in maintenance mode.
            || (defined('ABORT_AFTER_CONFIG') && ABORT_AFTER_CONFIG) // Only config requested.
            || (defined('CLI_SCRIPT') && CLI_SCRIPT) // Allow CLI scripts.
            || $outageinfo // Allow outage info requests.
@@ -89,7 +88,7 @@ if (!$allowed) {
     // Call the climaintenance.php which will check for the conditions
     // that have been baked into it from the frontend (ip, accesskey, etc...).
     $CFG->dirroot = dirname(dirname(dirname(__FILE__))); // It is not defined yet but the script below needs it.
-    require($CFG->dataroot.'/climaintenance.php'); // This call may terminate the script here or not.
+    require($CFG->dataroot . '/climaintenance.php'); // This call may terminate the script here or not.
 }
 
 // 4) Set flag this file was loaded.

--- a/checkfinished.php
+++ b/checkfinished.php
@@ -31,7 +31,7 @@ header('Cache-Control: public, max-age=10,s-maxage=10');
  // @codingStandardsIgnoreEnd
 define('NO_AUTH_OUTAGE', true);
 
-require_once(__DIR__.'/../../config.php');
+require_once(__DIR__ . '/../../config.php');
 
 $active = outagedb::get_active();
 

--- a/classes/calendar/calendar.php
+++ b/classes/calendar/calendar.php
@@ -20,7 +20,7 @@ use auth_outage\local\outage;
 use calendar_event;
 
 defined('MOODLE_INTERNAL') || die();
-require_once($CFG->dirroot.'/calendar/lib.php');
+require_once($CFG->dirroot . '/calendar/lib.php');
 
 /**
  * calendar class.
@@ -53,7 +53,7 @@ class calendar {
         $event = self::load($outage->id);
 
         if (is_null($event)) {
-            debugging('Cannot update calendar entry for outage #'.$outage->id.', event not found. Creating it...');
+            debugging('Cannot update calendar entry for outage #' . $outage->id . ', event not found. Creating it...');
             self::create($outage);
         } else {
             $event->update(self::create_data($outage), false);
@@ -69,7 +69,7 @@ class calendar {
 
         // If not found (was not created before) ignore it.
         if (is_null($event)) {
-            debugging('Cannot delete calendar entry for outage #'.$outageid.', event not found. Ignoring it...');
+            debugging('Cannot delete calendar entry for outage #' . $outageid . ', event not found. Ignoring it...');
         } else {
             $event->delete();
         }

--- a/classes/dml/outagedb.php
+++ b/classes/dml/outagedb.php
@@ -26,7 +26,7 @@ use coding_exception;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot.'/calendar/lib.php');
+require_once($CFG->dirroot . '/calendar/lib.php');
 
 /**
  * outagedb class.
@@ -118,7 +118,6 @@ class outagedb {
             // Create calendar entry.
             calendar::create($outage);
         } else {
-
             $other = (array) $outage;
             $other['title'] = $outage->get_title();
             $event = outage_updated::create([
@@ -208,8 +207,10 @@ class outagedb {
             $outagecache = new outage(json_decode($outageinfo));
         }
 
-        if ($outagecache && $outagecache->warntime <= $time && $outagecache->stoptime >= $time
-            && (!$outagecache->finished || $outagecache->finished >= $time)) {
+        if (
+            $outagecache && $outagecache->warntime <= $time && $outagecache->stoptime >= $time
+            && (!$outagecache->finished || $outagecache->finished >= $time)
+        ) {
             return  $outagecache;
         }
         return null;
@@ -238,7 +239,8 @@ class outagedb {
             ':datetime1 < stoptime AND (finished IS NULL OR :datetime2 < finished)',
             ['datetime1' => $time, 'datetime2' => $time],
             'starttime ASC, stoptime DESC, title ASC',
-            '*');
+            '*'
+        );
         foreach ($rs as $r) {
             $outages[] = new outage($r);
         }
@@ -270,7 +272,8 @@ class outagedb {
             'NOT (:datetime1 < stoptime AND (finished IS NULL OR :datetime2 < finished))',
             ['datetime1' => $time, 'datetime2' => $time],
             'stoptime DESC, starttime DESC, title ASC',
-            '*');
+            '*'
+        );
         foreach ($rs as $r) {
             $outages[] = new outage($r);
         }
@@ -295,12 +298,12 @@ class outagedb {
 
         $outage = self::get_by_id($id);
         if (is_null($outage)) {
-            debugging('Cannot finish outage #'.$id.': outage not found.');
+            debugging('Cannot finish outage #' . $id . ': outage not found.');
             return;
         }
 
         if (!$outage->is_ongoing($time)) {
-            debugging('Cannot finish outage #'.$id.': outage not ongoing.');
+            debugging('Cannot finish outage #' . $id . ': outage not ongoing.');
             return;
         }
 

--- a/classes/form/outage/delete.php
+++ b/classes/form/outage/delete.php
@@ -17,7 +17,7 @@
 namespace auth_outage\form\outage;
 
 defined('MOODLE_INTERNAL') || die();
-require_once($CFG->libdir.'/formslib.php');
+require_once($CFG->libdir . '/formslib.php');
 
 /**
  * delete class.

--- a/classes/form/outage/edit.php
+++ b/classes/form/outage/edit.php
@@ -22,7 +22,7 @@ use moodleform;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir.'/formslib.php');
+require_once($CFG->libdir . '/formslib.php');
 
 /**
  * edit class.
@@ -64,7 +64,7 @@ class edit extends moodleform {
             'text',
             'title',
             get_string('title', 'auth_outage'),
-            'maxlength="'.self::TITLE_MAX_CHARS.'" size="60"'
+            'maxlength="' . self::TITLE_MAX_CHARS . '" size="60"'
         );
         $mform->setType('title', PARAM_TEXT);
         $mform->addHelpButton('title', 'title', 'auth_outage');
@@ -75,8 +75,13 @@ class edit extends moodleform {
         $mform->addElement('static', 'usagehints', '', get_string('textplaceholdershint', 'auth_outage'));
         $mform->addElement('static', 'warningreenablemaintenancemode', '');
 
-        $mform->addElement('advcheckbox', 'useaccesskey', get_string('useaccesskey', 'auth_outage'),
-            get_string('useaccesskey:desc', 'auth_outage'), 0);
+        $mform->addElement(
+            'advcheckbox',
+            'useaccesskey',
+            get_string('useaccesskey', 'auth_outage'),
+            get_string('useaccesskey:desc', 'auth_outage'),
+            0
+        );
 
         $mform->addElement('text', 'accesskey', get_string('accesskey', 'auth_outage'));
         $mform->setType('accesskey', PARAM_TEXT);
@@ -125,7 +130,7 @@ class edit extends moodleform {
             return null;
         }
         if ($data->description['format'] != '1') {
-            debugging('Not implemented for format '.$data->description['format'], DEBUG_DEVELOPER);
+            debugging('Not implemented for format ' . $data->description['format'], DEBUG_DEVELOPER);
             return null;
         }
         $outagedata = [
@@ -165,8 +170,10 @@ class edit extends moodleform {
             ]);
 
             // If the default_autostart is configured in config, then force autostart to be the default value.
-            if (array_key_exists('auth_outage', $CFG->forced_plugin_settings)
-                && array_key_exists('default_autostart', $CFG->forced_plugin_settings['auth_outage'])) {
+            if (
+                array_key_exists('auth_outage', $CFG->forced_plugin_settings)
+                && array_key_exists('default_autostart', $CFG->forced_plugin_settings['auth_outage'])
+            ) {
                 $this->_form->setDefaults([
                     'autostart' => $CFG->forced_plugin_settings['auth_outage']['default_autostart'],
                 ]);
@@ -175,8 +182,10 @@ class edit extends moodleform {
 
             if (!empty($outage->id) && $outage->autostart && $outage->starttime < time() && $outage->stoptime > time()) {
                 $warning = $mform->getElement('warningreenablemaintenancemode');
-                $warning->setValue($OUTPUT->notification(get_string('warningreenablemaintenancemode', 'auth_outage'),
-                    'notifywarning'));
+                $warning->setValue($OUTPUT->notification(
+                    get_string('warningreenablemaintenancemode', 'auth_outage'),
+                    'notifywarning'
+                ));
             }
         } else {
             throw new coding_exception('$outage must be an outage object.', $outage);

--- a/classes/form/outage/finish.php
+++ b/classes/form/outage/finish.php
@@ -20,7 +20,7 @@ use moodleform;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir.'/formslib.php');
+require_once($CFG->libdir . '/formslib.php');
 
 /**
  * finish class.

--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -28,7 +28,6 @@ use core\hook\output\before_standard_top_of_body_html_generation;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class hook_callbacks {
-
     /**
      * Inject the warning bar into the page if there is currently an outage.
      *

--- a/classes/local/cli/cli_exception.php
+++ b/classes/local/cli/cli_exception.php
@@ -79,6 +79,6 @@ class cli_exception extends Exception {
      * @param Exception|null $previous Another exception as reference or null.
      */
     public function __construct($message, $code = 1, ?Exception $previous = null) {
-        parent::__construct('*ERROR* '.$message, $code, $previous = null);
+        parent::__construct('*ERROR* ' . $message, $code, $previous = null);
     }
 }

--- a/classes/local/cli/clibase.php
+++ b/classes/local/cli/clibase.php
@@ -46,7 +46,7 @@ abstract class clibase {
      */
     public function __construct(?array $options = null) {
         global $CFG;
-        require_once($CFG->libdir.'/clilib.php');
+        require_once($CFG->libdir . '/clilib.php');
 
         $warning = outagelib::generate_plugin_configuration_warning();
         if ($warning) {
@@ -57,11 +57,13 @@ abstract class clibase {
 
         if (is_null($options)) {
             // Using Moodle CLI API to read the parameters.
-            list($options, $unrecognized) = cli_get_params($this->generate_options(), $this->generate_shortcuts());
+            [$options, $unrecognized] = cli_get_params($this->generate_options(), $this->generate_shortcuts());
             if ($unrecognized) {
                 $unrecognized = implode("\n  ", $unrecognized);
-                throw new cli_exception(get_string('cliunknowoption', 'admin', $unrecognized),
-                    cli_exception::ERROR_PARAMETER_UNKNOWN);
+                throw new cli_exception(
+                    get_string('cliunknowoption', 'admin', $unrecognized),
+                    cli_exception::ERROR_PARAMETER_UNKNOWN
+                );
             }
         } else {
             // If not using Moodle CLI API to read parameters, ensure all keys exist.
@@ -129,13 +131,13 @@ abstract class clibase {
         $options = $this->generate_options();
         $shorts = array_flip($this->generate_shortcuts());
 
-        printf("%s\n\n", get_string('cli'.$cliname.'help', 'auth_outage'));
+        printf("%s\n\n", get_string('cli' . $cliname . 'help', 'auth_outage'));
         foreach (array_keys($options) as $long) {
-            $text = get_string('cli'.$cliname.'param'.$long, 'auth_outage');
-            $short = isset($shorts[$long]) ? ('-'.$shorts[$long].',') : '';
-            $long = '--'.$long;
+            $text = get_string('cli' . $cliname . 'param' . $long, 'auth_outage');
+            $short = isset($shorts[$long]) ? ('-' . $shorts[$long] . ',') : '';
+            $long = '--' . $long;
             printf("  %-4s %-20s %s\n", $short, $long, $text);
         }
-        printf("\n%s\n\n", get_string('cli'.$cliname.'examples', 'auth_outage'));
+        printf("\n%s\n\n", get_string('cli' . $cliname . 'examples', 'auth_outage'));
     }
 }

--- a/classes/local/cli/create.php
+++ b/classes/local/cli/create.php
@@ -83,7 +83,7 @@ class create extends clibase {
         // Check if any extra parameter was given.
         foreach (array_keys($defaults) as $key) {
             if (!array_key_exists($key, $missing)) {
-                throw new coding_exception('$default['.$key.'] is not valid.');
+                throw new coding_exception('$default[' . $key . '] is not valid.');
             }
             unset($missing[$key]);
         }
@@ -91,7 +91,7 @@ class create extends clibase {
         // Check if any required parameter is missing.
         foreach (array_keys($missing) as $k => $v) {
             if (is_null($v)) {
-                throw new coding_exception('$default[] missing: '.$k);
+                throw new coding_exception('$default[] missing: ' . $k);
             }
         }
 
@@ -110,8 +110,10 @@ class create extends clibase {
 
         // If not help mode, 'start' is required and cannot use default.
         if (is_null($this->options['start'])) {
-            throw new cli_exception(get_string('clierrormissingparamaters', 'auth_outage'),
-                cli_exception::ERROR_PARAMETER_MISSING);
+            throw new cli_exception(
+                get_string('clierrormissingparamaters', 'auth_outage'),
+                cli_exception::ERROR_PARAMETER_MISSING
+            );
         }
 
         // If cloning, set defaults to outage being cloned.
@@ -189,8 +191,10 @@ class create extends clibase {
     private function clone_defaults() {
         $id = $this->options['clone'];
         if (!is_number($id) || ($id <= 0)) {
-            throw new cli_exception(get_string('clierrorinvalidvaluenotid', 'auth_outage', ['param' => 'clone']),
-                cli_exception::ERROR_PARAMETER_INVALID);
+            throw new cli_exception(
+                get_string('clierrorinvalidvaluenotid', 'auth_outage', ['param' => 'clone']),
+                cli_exception::ERROR_PARAMETER_INVALID
+            );
         }
 
         $outage = outagedb::get_by_id((int)$id);
@@ -234,13 +238,17 @@ class create extends clibase {
      */
     private function merge_options_check_parameters_int_nonnegative($option, $param) {
         if (!is_number($option)) {
-            throw new cli_exception(get_string('clierrorinvalidvaluenotnumber', 'auth_outage', ['param' => $param]),
-                cli_exception::ERROR_PARAMETER_INVALID);
+            throw new cli_exception(
+                get_string('clierrorinvalidvaluenotnumber', 'auth_outage', ['param' => $param]),
+                cli_exception::ERROR_PARAMETER_INVALID
+            );
         }
         $option = (int)$option;
         if ($option < 0) {
-            throw new cli_exception(get_string('clierrorinvalidvaluenegativenumber', 'auth_outage', ['param' => $param]),
-                cli_exception::ERROR_PARAMETER_INVALID);
+            throw new cli_exception(
+                get_string('clierrorinvalidvaluenegativenumber', 'auth_outage', ['param' => $param]),
+                cli_exception::ERROR_PARAMETER_INVALID
+            );
         }
         return $option;
     }
@@ -254,13 +262,17 @@ class create extends clibase {
      */
     private function merge_options_check_parameters_string_nonempty($option, $param) {
         if (!is_string($option)) {
-            throw new cli_exception(get_string('clierrorinvalidvaluenotstring', 'auth_outage', ['param' => $param]),
-                cli_exception::ERROR_PARAMETER_INVALID);
+            throw new cli_exception(
+                get_string('clierrorinvalidvaluenotstring', 'auth_outage', ['param' => $param]),
+                cli_exception::ERROR_PARAMETER_INVALID
+            );
         }
         $option = trim($option);
         if (strlen($option) == 0) {
-            throw new cli_exception(get_string('clierrorinvalidvalueemptystring', 'auth_outage', ['param' => $param]),
-                cli_exception::ERROR_PARAMETER_INVALID);
+            throw new cli_exception(
+                get_string('clierrorinvalidvalueemptystring', 'auth_outage', ['param' => $param]),
+                cli_exception::ERROR_PARAMETER_INVALID
+            );
         }
         return $option;
     }
@@ -287,7 +299,9 @@ class create extends clibase {
             }
         }
 
-        throw new cli_exception(get_string('clierrorinvalidvaluenotbool', 'auth_outage', ['param' => $param]),
-            cli_exception::ERROR_PARAMETER_INVALID);
+        throw new cli_exception(
+            get_string('clierrorinvalidvaluenotbool', 'auth_outage', ['param' => $param]),
+            cli_exception::ERROR_PARAMETER_INVALID
+        );
     }
 }

--- a/classes/local/cli/finish.php
+++ b/classes/local/cli/finish.php
@@ -66,16 +66,20 @@ class finish extends clibase {
 
         // Cannot run during CLI_MAINTENANCE mode.
         if (CLI_MAINTENANCE) {
-            throw new cli_exception(get_string('cliinmaintenancemode', 'auth_outage'),
-                cli_exception::ERROR_MAINTENANCE_MODE);
+            throw new cli_exception(
+                get_string('cliinmaintenancemode', 'auth_outage'),
+                cli_exception::ERROR_MAINTENANCE_MODE
+            );
         }
 
         // Requires outageid or active but not both at the same time.
         $byid = !is_null($this->options['outageid']);
         $byactive = $this->options['active'];
         if ($byid == $byactive) {
-            throw new cli_exception(get_string('cliwaitforiterroridxoractive', 'auth_outage'),
-                cli_exception::ERROR_PARAMETER_MISSING);
+            throw new cli_exception(
+                get_string('cliwaitforiterroridxoractive', 'auth_outage'),
+                cli_exception::ERROR_PARAMETER_MISSING
+            );
         }
 
         $outage = $this->get_outage();
@@ -97,8 +101,10 @@ class finish extends clibase {
         } else {
             $id = $this->options['outageid'];
             if (!is_number($id) || ($id <= 0)) {
-                throw new cli_exception(get_string('clierrorinvalidvalue', 'auth_outage', ['param' => 'outageid']),
-                    cli_exception::ERROR_PARAMETER_INVALID);
+                throw new cli_exception(
+                    get_string('clierrorinvalidvalue', 'auth_outage', ['param' => 'outageid']),
+                    cli_exception::ERROR_PARAMETER_INVALID
+                );
             }
             $outage = outagedb::get_by_id((int)$id);
         }

--- a/classes/local/cli/waitforit.php
+++ b/classes/local/cli/waitforit.php
@@ -90,8 +90,10 @@ class waitforit extends clibase {
         $byid = !is_null($this->options['outageid']);
         $byactive = $this->options['active'];
         if ($byid == $byactive) {
-            throw new cli_exception(get_string('cliwaitforiterroridxoractive', 'auth_outage'),
-                cli_exception::ERROR_PARAMETER_INVALID);
+            throw new cli_exception(
+                get_string('cliwaitforiterroridxoractive', 'auth_outage'),
+                cli_exception::ERROR_PARAMETER_INVALID
+            );
         }
 
         $this->verbose('Verbose mode activated.');
@@ -100,11 +102,11 @@ class waitforit extends clibase {
 
         while ($sleep = $this->wait_for_outage_to_start($outage)) {
             if (is_null($this->sleepcallback)) {
-                $this->verbose('Sleeping for '.$sleep.' second(s).');
+                $this->verbose('Sleeping for ' . $sleep . ' second(s).');
                 sleep($sleep);
                 $this->time = time();
             } else {
-                $this->verbose('Calling callback to sleep '.$sleep.' second(s).');
+                $this->verbose('Calling callback to sleep ' . $sleep . ' second(s).');
                 $callback = $this->sleepcallback;
                 $this->time = $callback($sleep);
             }
@@ -136,10 +138,12 @@ class waitforit extends clibase {
         } else {
             $id = $this->options['outageid'];
             if (!is_number($id) || ($id <= 0)) {
-                throw new cli_exception(get_string('clierrorinvalidvalue', 'auth_outage', ['param' => 'outageid']),
-                    cli_exception::ERROR_PARAMETER_INVALID);
+                throw new cli_exception(
+                    get_string('clierrorinvalidvalue', 'auth_outage', ['param' => 'outageid']),
+                    cli_exception::ERROR_PARAMETER_INVALID
+                );
             }
-            $this->verbose('Querying database for outage #'.$id.'...');
+            $this->verbose('Querying database for outage #' . $id . '...');
             $outage = outagedb::get_by_id((int)$id);
         }
 
@@ -147,7 +151,7 @@ class waitforit extends clibase {
             throw new cli_exception(get_string('clierroroutagenotfound', 'auth_outage'), cli_exception::ERROR_OUTAGE_NOT_FOUND);
         }
 
-        $this->verbose('Found outage #'.$outage->id.': '.$outage->get_title());
+        $this->verbose('Found outage #' . $outage->id . ': ' . $outage->get_title());
         return $outage;
     }
 

--- a/classes/local/controllers/infopage.php
+++ b/classes/local/controllers/infopage.php
@@ -114,7 +114,7 @@ class infopage {
             'admin' => is_siteadmin(),
             'outage' => $this->outage,
         ];
-        require($CFG->dirroot.'/auth/outage/views/info/content.php');
+        require($CFG->dirroot . '/auth/outage/views/info/content.php');
 
         // Moodle 2.7 did not check for CLI mode, which was fixed later.
         if (!($CFG->branch == '27' && CLI_SCRIPT)) {
@@ -133,7 +133,7 @@ class infopage {
         }
 
         if (!is_null($params['id']) && !is_null($params['outage']) && ($params['id'] !== $params['outage']->id)) {
-            throw new coding_exception('Provided id and outage->id do not match.', $params['id'].'/'.$params['outage']->id);
+            throw new coding_exception('Provided id and outage->id do not match.', $params['id'] . '/' . $params['outage']->id);
         }
 
         if (is_null($params['id']) && is_null($params['outage'])) {

--- a/classes/local/controllers/maintenance_static_page.php
+++ b/classes/local/controllers/maintenance_static_page.php
@@ -50,7 +50,8 @@ class maintenance_static_page {
             $html = '<html></html>';
         } else {
             $data = maintenance_static_page_io::file_get_data(
-                $CFG->wwwroot.'/auth/outage/info.php?auth_outage_hide_warning=1&static=1&id='.$outage->id);
+                $CFG->wwwroot . '/auth/outage/info.php?auth_outage_hide_warning=1&static=1&id=' . $outage->id
+            );
             $html = $data['contents'];
         }
 

--- a/classes/local/controllers/maintenance_static_page_generator.php
+++ b/classes/local/controllers/maintenance_static_page_generator.php
@@ -74,7 +74,6 @@ class maintenance_static_page_generator {
         $this->io->cleanup();
 
         if (!is_null($this->dom)) {
-
             // This can take a while to process using repeated curls.
             core_php_time_limit::raise();
 
@@ -184,9 +183,9 @@ class maintenance_static_page_generator {
                 $fullurl = $originalurl;
             } else if ($originalurl[0] == '/') {
                 $rooturl = parse_url($CFG->wwwroot);
-                $fullurl = $rooturl['scheme'].'://'.$rooturl['host'].$originalurl;
+                $fullurl = $rooturl['scheme'] . '://' . $rooturl['host'] . $originalurl;
             } else {
-                $fullurl = $baseref.'/'.$originalurl;
+                $fullurl = $baseref . '/' . $originalurl;
             }
 
             $saved = $this->io->save_url_file($fullurl);
@@ -253,7 +252,7 @@ class maintenance_static_page_generator {
                     $fullurl = (string) new moodle_url($matches[1]);
                 }
                 $newurl = $this->io->generate_file_url($fullurl);
-                $updated = preg_replace(self::PATTERN, ' url('.$newurl.') ', $style);
+                $updated = preg_replace(self::PATTERN, ' url(' . $newurl . ') ', $style);
                 $element->setAttribute('style', $updated);
             }
         }

--- a/classes/local/controllers/maintenance_static_page_io.php
+++ b/classes/local/controllers/maintenance_static_page_io.php
@@ -61,7 +61,7 @@ class maintenance_static_page_io {
         }
 
         if ($result['contents'] === false) {
-            debugging('Cannot fetch: '.$file);
+            debugging('Cannot fetch: ' . $file);
             $result = ['contents' => '', 'mime' => 'unknown'];
         }
         return $result;
@@ -85,9 +85,9 @@ class maintenance_static_page_io {
     public function get_template_file() {
         global $CFG;
         if ($this->preview) {
-            return $this->get_resources_folder().'/climaintenance.html';
+            return $this->get_resources_folder() . '/climaintenance.html';
         } else {
-            return $CFG->dataroot.'/climaintenance.template.html';
+            return $CFG->dataroot . '/climaintenance.template.html';
         }
     }
 
@@ -102,10 +102,10 @@ class maintenance_static_page_io {
         global $CFG;
 
         // If you change the path, also change file auth/outage/bootstrap.php as it does not use this reference.
-        $dir = $CFG->dataroot.'/auth_outage/climaintenance';
+        $dir = $CFG->dataroot . '/auth_outage/climaintenance';
 
         if ($this->preview) {
-            $dir = $dir.'/preview';
+            $dir = $dir . '/preview';
         }
         return $dir;
     }
@@ -155,18 +155,18 @@ class maintenance_static_page_io {
         $dir = realpath($dir);
         $safedir = $this->get_resources_folder();
         if (substr($dir, 0, strlen($safedir)) !== $safedir) {
-            throw new invalid_parameter_exception('Unsafe to delete: '.$dir);
+            throw new invalid_parameter_exception('Unsafe to delete: ' . $dir);
         }
 
         if (!is_dir($dir)) {
-            throw new coding_exception('Not a directory: '.$dir);
+            throw new coding_exception('Not a directory: ' . $dir);
         }
         $files = scandir($dir);
         foreach ($files as $file) {
             if (($file == '.') || ($file == '..')) {
                 continue;
             }
-            $file = $dir.'/'.$file;
+            $file = $dir . '/' . $file;
             if (is_file($file)) {
                 unlink($file);
                 continue;
@@ -175,7 +175,7 @@ class maintenance_static_page_io {
                 $this->delete_directory_recursively($file);
                 continue;
             }
-            throw new coding_exception('Not a file or directory: '.$file);
+            throw new coding_exception('Not a file or directory: ' . $file);
         }
         rmdir($dir);
     }
@@ -211,7 +211,7 @@ class maintenance_static_page_io {
         global $CFG;
 
         if (!self::is_url($url)) {
-            debugging('Found a relative url ('.$url.') -- is it using moodle_url()?');
+            debugging('Found a relative url (' . $url . ') -- is it using moodle_url()?');
             return null; // Leave hardcoded URLs as it is.
         }
 
@@ -227,12 +227,12 @@ class maintenance_static_page_io {
         $data = self::file_get_data($url);
 
         $mime = trim(base64_encode($data['mime']), '=');
-        $url = sha1($data['contents']).'.'.$mime;
-        $filepath = $this->get_resources_folder().'/'.$url;
+        $url = sha1($data['contents']) . '.' . $mime;
+        $filepath = $this->get_resources_folder() . '/' . $url;
         file_put_contents($filepath, $data['contents']);
 
         if ($this->preview) {
-            $url = 'preview/'.$url;
+            $url = 'preview/' . $url;
         }
 
         return ['file' => $filepath, 'url' => $url];

--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -26,7 +26,7 @@ use invalid_parameter_exception;
 use stdClass;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/../../lib.php');
+require_once(__DIR__ . '/../../lib.php');
 
 /**
  * outagelib class.
@@ -37,7 +37,6 @@ require_once(__DIR__.'/../../lib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class outagelib {
-
     /** Outage start. */
     const OUTAGE_START = '<!-- OUTAGESTART -->';
 
@@ -135,7 +134,7 @@ class outagelib {
             $renderer = $PAGE->get_renderer('auth_outage');
             return $renderer->render_warningbar($active, $time, false, $preview);
         } catch (Exception $e) {
-            debugging('Exception occured while injecting our code: '.$e->getMessage());
+            debugging('Exception occured while injecting our code: ' . $e->getMessage());
             debugging($e->getTraceAsString(), DEBUG_DEVELOPER);
         }
     }
@@ -230,7 +229,7 @@ class outagelib {
             $message = get_config('moodle', 'maintenance_message');
             if ($message) {
                 debugging('Disabling $CFG->maintenance_message to allow our template page to take place.');
-                debugging('Previous value: '.$message);
+                debugging('Previous value: ' . $message);
                 // We cannot do much if forced config, but the logs will show the error.
                 unset_config('maintenance_message');
             }
@@ -253,7 +252,7 @@ class outagelib {
         self::$injectcalled = true;
 
         // Do not inject into admin/settings.php.
-        if ($_SERVER['SCRIPT_NAME'] == '/'.$CFG->admin.'/settings.php') {
+        if ($_SERVER['SCRIPT_NAME'] == '/' . $CFG->admin . '/settings.php') {
             if (optional_param('section', '', PARAM_RAW) === 'additionalhtml') {
                 return false;
             }
@@ -381,7 +380,7 @@ EOT;
      */
     public static function update_climaintenance_code($outage) {
         global $CFG;
-        $file = $CFG->dataroot.'/climaintenance.php';
+        $file = $CFG->dataroot . '/climaintenance.php';
 
         if (!is_null($outage) && !($outage instanceof outage)) {
             throw new coding_exception('$outage must be null or an outage object.');
@@ -401,7 +400,7 @@ EOT;
 
             $dir = dirname($file);
             if (!file_exists($dir) || !is_dir($dir)) {
-                throw new file_exception('Directory must exists: '.$dir);
+                throw new file_exception('Directory must exists: ' . $dir);
             }
             file_put_contents($file, $code);
         }
@@ -417,8 +416,10 @@ EOT;
 
         $message = [];
 
-        if (trim(self::get_config()->allowedips) != ''
-                && (!isset($CFG->auth_outage_bootstrap_loaded) || !$CFG->auth_outage_bootstrap_loaded)) {
+        if (
+            trim(self::get_config()->allowedips) != ''
+                && (!isset($CFG->auth_outage_bootstrap_loaded) || !$CFG->auth_outage_bootstrap_loaded)
+        ) {
             $message[] = get_string('configurationwarning', 'auth_outage');
         }
 

--- a/classes/output/manage/base_table.php
+++ b/classes/output/manage/base_table.php
@@ -22,7 +22,7 @@ use html_writer;
 use moodle_url;
 
 defined('MOODLE_INTERNAL') || die();
-require_once($CFG->libdir.'/tablelib.php');
+require_once($CFG->libdir . '/tablelib.php');
 
 /**
  * base_table class.
@@ -58,7 +58,7 @@ class base_table extends flexible_table {
         global $PAGE;
 
         $id = (is_null($id) ? self::$autoid++ : $id);
-        parent::__construct('auth_outage_manage_'.$id);
+        parent::__construct('auth_outage_manage_' . $id);
 
         $this->define_baseurl($PAGE->url);
         $this->set_attribute('class', 'generaltable admintable');
@@ -77,7 +77,7 @@ class base_table extends flexible_table {
         // View button.
         $buttons .= html_writer::link(
             new moodle_url('/auth/outage/info.php', ['id' => $outage->id]),
-            $OUTPUT->pix_icon('t/preview', get_string('view'), 'moodle', array('class' => 'iconsmall')),
+            $OUTPUT->pix_icon('t/preview', get_string('view'), 'moodle', ['class' => 'iconsmall']),
             [
                 'title' => get_string('view'),
                 'target' => '_blank',
@@ -88,7 +88,7 @@ class base_table extends flexible_table {
         if ($editdelete) {
             $buttons .= html_writer::link(
                 new moodle_url('/auth/outage/edit.php', ['edit' => $outage->id]),
-                $OUTPUT->pix_icon('t/edit', get_string('edit'), 'moodle', array('class' => 'iconsmall')),
+                $OUTPUT->pix_icon('t/edit', get_string('edit'), 'moodle', ['class' => 'iconsmall']),
                 ['title' => get_string('edit')]
             );
         }
@@ -96,7 +96,7 @@ class base_table extends flexible_table {
         // Clone button.
         $buttons .= html_writer::link(
             new moodle_url('/auth/outage/edit.php', ['clone' => $outage->id]),
-            $OUTPUT->pix_icon('t/copy', get_string('clone', 'auth_outage'), 'moodle', array('class' => 'iconsmall')),
+            $OUTPUT->pix_icon('t/copy', get_string('clone', 'auth_outage'), 'moodle', ['class' => 'iconsmall']),
             ['title' => get_string('clone', 'auth_outage')]
         );
 
@@ -104,7 +104,7 @@ class base_table extends flexible_table {
         if ($outage->is_ongoing()) {
             $buttons .= html_writer::link(
                 new moodle_url('/auth/outage/finish.php', ['id' => $outage->id]),
-                $OUTPUT->pix_icon('t/check', get_string('finish', 'auth_outage'), 'moodle', array('class' => 'iconsmall')),
+                $OUTPUT->pix_icon('t/check', get_string('finish', 'auth_outage'), 'moodle', ['class' => 'iconsmall']),
                 ['title' => get_string('finish', 'auth_outage')]
             );
         }
@@ -113,7 +113,7 @@ class base_table extends flexible_table {
         if ($editdelete) {
             $buttons .= html_writer::link(
                 new moodle_url('/auth/outage/delete.php', ['id' => $outage->id]),
-                $OUTPUT->pix_icon('t/delete', get_string('delete'), 'moodle', array('class' => 'iconsmall')),
+                $OUTPUT->pix_icon('t/delete', get_string('delete'), 'moodle', ['class' => 'iconsmall']),
                 ['title' => get_string('delete')]
             );
         }

--- a/classes/output/manage/history_table.php
+++ b/classes/output/manage/history_table.php
@@ -19,7 +19,7 @@ namespace auth_outage\output\manage;
 use auth_outage\local\outage;
 
 defined('MOODLE_INTERNAL') || die();
-require_once($CFG->libdir.'/tablelib.php');
+require_once($CFG->libdir . '/tablelib.php');
 
 /**
  * history_table class.
@@ -45,8 +45,7 @@ class history_table extends base_table {
                 get_string('tableheaderdurationactual', 'auth_outage'),
                 get_string('tableheadertitle', 'auth_outage'),
                 get_string('actions'),
-            ]
-        );
+            ]);
 
         $this->setup();
     }

--- a/classes/output/manage/planned_table.php
+++ b/classes/output/manage/planned_table.php
@@ -21,7 +21,7 @@ use html_writer;
 use moodle_url;
 
 defined('MOODLE_INTERNAL') || die();
-require_once($CFG->libdir.'/tablelib.php');
+require_once($CFG->libdir . '/tablelib.php');
 
 /**
  * planned_table class.

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -45,7 +45,7 @@ class renderer extends plugin_renderer_base {
         $viewbag['viewfile'] = $view;
         unset($view);
 
-        require($CFG->dirroot.'/auth/outage/views/'.$viewbag['viewfile']);
+        require($CFG->dirroot . '/auth/outage/views/' . $viewbag['viewfile']);
     }
 
     /**
@@ -88,8 +88,8 @@ class renderer extends plugin_renderer_base {
      * @return string HTML for the page.
      */
     public function renderdeleteconfirmation(outage $outage) {
-        return $this->rendersubtitle('outagedelete').
-               html_writer::tag('p', get_string('outagedeletewarning', 'auth_outage')).
+        return $this->rendersubtitle('outagedelete') .
+               html_writer::tag('p', get_string('outagedeletewarning', 'auth_outage')) .
                $this->renderoutage($outage, false);
     }
 
@@ -99,8 +99,8 @@ class renderer extends plugin_renderer_base {
      * @return string HTML for the page.
      */
     public function renderfinishconfirmation(outage $outage) {
-        return $this->rendersubtitle('outagefinish').
-               html_writer::tag('p', get_string('outagefinishwarning', 'auth_outage')).
+        return $this->rendersubtitle('outagefinish') .
+               html_writer::tag('p', get_string('outagefinishwarning', 'auth_outage')) .
                $this->renderoutage($outage, false);
     }
 
@@ -147,7 +147,7 @@ class renderer extends plugin_renderer_base {
             $created = core_user::get_user($outage->createdby, 'firstname,lastname', MUST_EXIST);
             $created = html_writer::link(
                 new moodle_url('/user/profile.php', ['id' => $outage->createdby]),
-                trim($created->firstname.' '.$created->lastname)
+                trim($created->firstname . ' ' . $created->lastname)
             );
         }
 
@@ -157,7 +157,7 @@ class renderer extends plugin_renderer_base {
             $modified = core_user::get_user($outage->modifiedby, 'firstname,lastname', MUST_EXIST);
             $modified = html_writer::link(
                 new moodle_url('/user/profile.php', ['id' => $outage->modifiedby]),
-                trim($modified->firstname.' '.$modified->lastname)
+                trim($modified->firstname . ' ' . $modified->lastname)
             );
         }
 
@@ -185,33 +185,35 @@ class renderer extends plugin_renderer_base {
         $start = outagelib::OUTAGE_START;
         $end = outagelib::OUTAGE_END;
         $outagehtml = html_writer::div(
-            html_writer::tag('blockquote',
-                             html_writer::div(html_writer::tag('b', $outage->get_title(), ['data-id' => $outage->id])).
-                             html_writer::div(html_writer::tag('i', $outage->get_description())).
+            html_writer::tag(
+                'blockquote',
+                html_writer::div(html_writer::tag('b', $outage->get_title(), ['data-id' => $outage->id])) .
+                             html_writer::div(html_writer::tag('i', $outage->get_description())) .
                              html_writer::div(
-                                 html_writer::tag('b', get_string('tableheaderwarnbefore', 'auth_outage').': ').
+                                 html_writer::tag('b', get_string('tableheaderwarnbefore', 'auth_outage') . ': ') .
                                  format_time($outage->get_warning_duration())
-                             ).
+                             ) .
                              html_writer::div(
-                                 html_writer::tag('b', get_string('tableheaderstarttime', 'auth_outage').': ').
+                                 html_writer::tag('b', get_string('tableheaderstarttime', 'auth_outage') . ': ') .
                                  userdate($outage->starttime, get_string('datetimeformat', 'auth_outage'))
-                             ).
+                             ) .
                              html_writer::div(
-                                 html_writer::tag('b', get_string('tableheaderdurationplanned', 'auth_outage').': ').
+                                 html_writer::tag('b', get_string('tableheaderdurationplanned', 'auth_outage') . ': ') .
                                  format_time($outage->get_duration_planned())
-                             ).
+                             ) .
                              html_writer::div(
-                                 html_writer::tag('b', get_string('tableheaderdurationactual', 'auth_outage').': ').
+                                 html_writer::tag('b', get_string('tableheaderdurationactual', 'auth_outage') . ': ') .
                                  $finished
-                             ).
+                             ) .
                              html_writer::div(
-                                 html_writer::tag('small',
-                                                  'Created by '.$created.
-                                                  ', modified by '.$modified.' on '.
+                                 html_writer::tag(
+                                     'small',
+                                     'Created by ' . $created .
+                                                  ', modified by ' . $modified . ' on ' .
                                                   userdate($outage->lastmodified, get_string('datetimeformat', 'auth_outage'))
                                  )
-                             ).
-                             ($buttons ? html_writer::div($linkedit.$linkdelete) : '')
+                             ) .
+                             ($buttons ? html_writer::div($linkedit . $linkdelete) : '')
             )
         );
         return $start . $outagehtml . $end;

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -25,7 +25,6 @@ namespace auth_outage\privacy;
  */
 class provider implements
     \core_privacy\local\metadata\null_provider {
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
@@ -38,5 +37,4 @@ class provider implements
     public static function get_reason(): string {
         return 'privacy:no_data_reason';
     }
-
 }

--- a/cli/create.php
+++ b/cli/create.php
@@ -28,8 +28,8 @@ use auth_outage\local\cli\create;
 use auth_outage\local\outagelib;
 
 define('CLI_SCRIPT', true);
-require_once(__DIR__.'/../../../config.php');
-require_once($CFG->libdir.'/clilib.php');
+require_once(__DIR__ . '/../../../config.php');
+require_once($CFG->libdir . '/clilib.php');
 
 try {
     $cli = new create();

--- a/cli/finish.php
+++ b/cli/finish.php
@@ -27,8 +27,8 @@ use auth_outage\local\cli\cli_exception;
 use auth_outage\local\cli\finish;
 
 define('CLI_SCRIPT', true);
-require_once(__DIR__.'/../../../config.php');
-require_once($CFG->libdir.'/clilib.php');
+require_once(__DIR__ . '/../../../config.php');
+require_once($CFG->libdir . '/clilib.php');
 
 try {
     $cli = new finish();
@@ -36,4 +36,3 @@ try {
 } catch (cli_exception $e) {
     cli_error($e->getMessage());
 }
-

--- a/cli/waitforit.php
+++ b/cli/waitforit.php
@@ -27,8 +27,8 @@ use auth_outage\local\cli\cli_exception;
 use auth_outage\local\cli\waitforit;
 
 define('CLI_SCRIPT', true);
-require_once(__DIR__.'/../../../config.php');
-require_once($CFG->libdir.'/clilib.php');
+require_once(__DIR__ . '/../../../config.php');
+require_once($CFG->libdir . '/clilib.php');
 
 try {
     $cli = new waitforit();
@@ -36,4 +36,3 @@ try {
 } catch (cli_exception $e) {
     cli_error($e->getMessage());
 }
-

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -48,7 +48,6 @@ function xmldb_auth_outage_upgrade($oldversion) {
     }
 
     if ($oldversion < 2024081900) {
-
         // Define field accesskey to be added to auth_outage.
         $table = new xmldb_table('auth_outage');
         $field = new xmldb_field('accesskey', XMLDB_TYPE_CHAR, '16', null, null, null, null, 'finished');

--- a/delete.php
+++ b/delete.php
@@ -27,9 +27,9 @@ use auth_outage\dml\outagedb;
 use auth_outage\form\outage\delete;
 use auth_outage\output\renderer;
 
-require_once(__DIR__.'/../../config.php');
-require_once($CFG->libdir.'/adminlib.php');
-require_once($CFG->libdir.'/formslib.php');
+require_once(__DIR__ . '/../../config.php');
+require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->libdir . '/formslib.php');
 
 admin_externalpage_setup('auth_outage_manage');
 $PAGE->set_url(new moodle_url('/auth/outage/manage.php'));
@@ -46,7 +46,7 @@ if ($mform->is_cancelled()) {
 $id = required_param('id', PARAM_INT);
 $outage = outagedb::get_by_id($id);
 if ($outage == null) {
-    throw new invalid_parameter_exception('Outage #'.$id.' not found.');
+    throw new invalid_parameter_exception('Outage #' . $id . ' not found.');
 }
 
 $dataid = new stdClass();

--- a/edit.php
+++ b/edit.php
@@ -29,9 +29,9 @@ use auth_outage\local\outage;
 use auth_outage\local\outagelib;
 use auth_outage\output\renderer;
 
-require_once(__DIR__.'/../../config.php');
-require_once($CFG->libdir.'/adminlib.php');
-require_once($CFG->libdir.'/formslib.php');
+require_once(__DIR__ . '/../../config.php');
+require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->libdir . '/formslib.php');
 
 admin_externalpage_setup('auth_outage_manage');
 $output = $PAGE->get_renderer('auth_outage');
@@ -100,7 +100,7 @@ if ($outage == null) {
 
 $mform->set_data($outage);
 
-$PAGE->navbar->add(get_string($action.'crumb', 'auth_outage'));
+$PAGE->navbar->add(get_string($action . 'crumb', 'auth_outage'));
 echo $output->header();
 echo $output->rendersubtitle($action);
 $mform->display();

--- a/file.php
+++ b/file.php
@@ -45,13 +45,13 @@ if (count($parts) != 2) {
 $mime = base64_decode($parts[1]);
 
 // Detect type, we only support css or PNG images.
-header('Content-Type: '.$mime);
+header('Content-Type: ' . $mime);
 
 // Use cache.
 $lifetime = 60 * 60 * 24; // 1 day.
-header('Expires: '.gmdate('D, d M Y H:i:s', time() + $lifetime).' GMT');
+header('Expires: ' . gmdate('D, d M Y H:i:s', time() + $lifetime) . ' GMT');
 header('Pragma: ');
-header('Cache-Control: public, max-age='.$lifetime);
+header('Cache-Control: public, max-age=' . $lifetime);
 header('Accept-Ranges: none');
 
 
@@ -60,7 +60,7 @@ header('Accept-Ranges: none');
  */
 function auth_outage_bootstrap_callback() {
     // Not using classes as classloader has not been initialized yet. Keep it minimalist.
-    require_once(__DIR__.'/lib.php');
+    require_once(__DIR__ . '/lib.php');
     $file = auth_outage_get_climaintenance_resource_file($_GET['file']);
     if (is_null($file)) {
         // @codingStandardsIgnoreStart
@@ -84,5 +84,5 @@ require_once(__DIR__.'/../../config.php');
 
 // We should never reach here if config.php and auth/outage/bootstrap.php intercepted it correctly.
 // If config.php did not execute the callback function we can use the debugging function here.
-debugging('Your config.php is not properly configured for auth/outage plugin. '.
+debugging('Your config.php is not properly configured for auth/outage plugin. ' .
           'Please check the plugin settings for information.');

--- a/finish.php
+++ b/finish.php
@@ -27,9 +27,9 @@ use auth_outage\dml\outagedb;
 use auth_outage\form\outage\finish;
 use auth_outage\output\renderer;
 
-require_once(__DIR__.'/../../config.php');
-require_once($CFG->libdir.'/adminlib.php');
-require_once($CFG->libdir.'/formslib.php');
+require_once(__DIR__ . '/../../config.php');
+require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->libdir . '/formslib.php');
 
 admin_externalpage_setup('auth_outage_manage');
 $PAGE->set_url(new moodle_url('/auth/outage/manage.php'));
@@ -46,7 +46,7 @@ if ($mform->is_cancelled()) {
 $id = required_param('id', PARAM_INT);
 $outage = outagedb::get_by_id($id);
 if ($outage == null) {
-    throw new invalid_parameter_exception('Outage #'.$id.' not found.');
+    throw new invalid_parameter_exception('Outage #' . $id . ' not found.');
 }
 
 $dataid = new stdClass();

--- a/lib.php
+++ b/lib.php
@@ -48,7 +48,7 @@ function auth_outage_get_climaintenance_resource_file($file) {
     // We are not using any external libraries or references in this file (we have not gully loaded config.php yet).
     // If you change the path below maybe you need to change maintenance_static_page::get_resources_folder() as well.
     $resourcedir = rtrim($CFG->dataroot, '/'); // In case the configuration has a trailing slash.
-    $resourcedir = $resourcedir.'/auth_outage/climaintenance';
+    $resourcedir = $resourcedir . '/auth_outage/climaintenance';
 
     // Protect against path traversal attacks.
     $basename = basename($file);
@@ -61,7 +61,7 @@ function auth_outage_get_climaintenance_resource_file($file) {
         return null;
     }
 
-    $realpath = realpath($resourcedir.'/'.$file);
+    $realpath = realpath($resourcedir . '/' . $file);
     return ($realpath == false) ? null : $realpath;
 }
 

--- a/manage.php
+++ b/manage.php
@@ -27,8 +27,8 @@ use auth_outage\dml\outagedb;
 use auth_outage\output\renderer;
 use auth_outage\local\outagelib;
 
-require_once(__DIR__.'/../../config.php');
-require_once($CFG->libdir.'/adminlib.php');
+require_once(__DIR__ . '/../../config.php');
+require_once($CFG->libdir . '/adminlib.php');
 
 admin_externalpage_setup('auth_outage_manage');
 $PAGE->set_url(new moodle_url('/auth/outage/manage.php'));

--- a/settings.php
+++ b/settings.php
@@ -89,7 +89,8 @@ if ($hassiteconfig) {
     $settings->add(new admin_setting_heading(
         'plugin',
         get_string('settingssectionplugin', 'auth_outage'),
-        get_string('settingssectionplugindescription', 'auth_outage')));
+        get_string('settingssectionplugindescription', 'auth_outage')
+    ));
 
     $settings->add(new admin_setting_configtextarea(
         'auth_outage/css',
@@ -152,7 +153,8 @@ if ($hassiteconfig) {
     // Clear '$settings' to prevent adding again outsite category.
     $settings = null;
     // Add options.
-    $ADMIN->add('auth_outage',
+    $ADMIN->add(
+        'auth_outage',
         new admin_externalpage(
             'auth_outage_manage',
             get_string('menumanage', 'auth_outage'),

--- a/tests/behat/behat_auth_outage.php
+++ b/tests/behat/behat_auth_outage.php
@@ -30,7 +30,7 @@ use auth_outage\local\outage;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 
-require_once(__DIR__ . '/../../../../public/lib/behat/behat_base.php');
+require_once(__DIR__ . '/../../../../lib/behat/behat_base.php');
 
 /**
  * Steps definitions related to auth_outage.

--- a/tests/behat/behat_auth_outage.php
+++ b/tests/behat/behat_auth_outage.php
@@ -30,7 +30,7 @@ use auth_outage\local\outage;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 
-require_once(__DIR__.'/../../../../public/lib/behat/behat_base.php');
+require_once(__DIR__ . '/../../../../public/lib/behat/behat_base.php');
 
 /**
  * Steps definitions related to auth_outage.
@@ -90,8 +90,8 @@ class behat_auth_outage extends behat_base {
         $data = [
             'autostart' => false,
             'finished' => null,
-            'title' => 'Example of '.$type.' outage',
-            'description' => 'An outage: '.$type,
+            'title' => 'Example of ' . $type . ' outage',
+            'description' => 'An outage: ' . $type,
         ];
         switch ($type) {
             case 'waiting':
@@ -121,7 +121,7 @@ class behat_auth_outage extends behat_base {
                 $data['stoptime'] = time() - (60 * 60 * 2); // Stopped 1 hour ago.
                 break;
             default:
-                throw new InvalidArgumentException('$type='.$type.' is not valid.');
+                throw new InvalidArgumentException('$type=' . $type . ' is not valid.');
         }
         outagedb::save(new outage($data));
     }
@@ -136,8 +136,8 @@ class behat_auth_outage extends behat_base {
         $expected = ($action == 'Edit') ? 2 : 1; // Edit is an action through the title or button.
         $found = $this->how_many_times_can_i_see_action($action);
         if ($found != $expected) {
-            throw new ExpectationException('"'.$action.'" action not found, expected '.$expected.
-                                           ' but found '.$found.'.', $this->getSession());
+            throw new ExpectationException('"' . $action . '" action not found, expected ' . $expected .
+                                           ' but found ' . $found . '.', $this->getSession());
         }
     }
 
@@ -149,7 +149,7 @@ class behat_auth_outage extends behat_base {
      */
     public function i_should_not_see_the_action($action) {
         if ($this->how_many_times_can_i_see_action($action) != 0) {
-            throw new ExpectationException('"'.$action.'" action was found', $this->getSession());
+            throw new ExpectationException('"' . $action . '" action was found', $this->getSession());
         }
     }
 
@@ -159,7 +159,7 @@ class behat_auth_outage extends behat_base {
      * @param string $name
      */
     public function i_should_see_an_empty_settings_text_area($name) {
-        $this->assertSession()->fieldValueEquals('s_auth_outage_'.$name, '');
+        $this->assertSession()->fieldValueEquals('s_auth_outage_' . $name, '');
     }
 
     /**
@@ -177,7 +177,7 @@ class behat_auth_outage extends behat_base {
      */
     private function how_many_times_can_i_see_action($action) {
         $selector = 'css';
-        $locator = "div[role='main'] a[title='".$action."']";
+        $locator = "div[role='main'] a[title='" . $action . "']";
         $items = $this->getSession()->getPage()->findAll($selector, $locator);
         return count($items);
     }
@@ -188,7 +188,7 @@ class behat_auth_outage extends behat_base {
      * @param string $action Action button to click.
      */
     public function i_click_on_the_action_button($action) {
-        $node = $this->get_selected_node('css_element', "div[role='main'] table nobr a[title='".$action."']");
+        $node = $this->get_selected_node('css_element', "div[role='main'] table nobr a[title='" . $action . "']");
         $this->ensure_node_is_visible($node);
         $node->click();
     }
@@ -205,7 +205,7 @@ class behat_auth_outage extends behat_base {
 
         $count = count($this->getSession()->getWindowNames());
         if ($count != 2) {
-            throw new ExpectationException('Number of windows: '.$count, $this->getSession());
+            throw new ExpectationException('Number of windows: ' . $count, $this->getSession());
         }
     }
 
@@ -220,17 +220,18 @@ class behat_auth_outage extends behat_base {
 
         $container = $this->getSession()->getPage()->findAll('css', $element);
         if (count($container) == 0) {
-            throw new ExpectationException('"'.$element.'" element not found', $this->getSession());
+            throw new ExpectationException('"' . $element . '" element not found', $this->getSession());
         }
         $container = $container[0];
 
         $xpathliteral = $this->getSession()->getSelectorsHandler()->xpathLiteral($text);
-        $xpath = "/descendant-or-self::*[contains(., $xpathliteral)]".
+        $xpath = "/descendant-or-self::*[contains(., $xpathliteral)]" .
                  "[count(descendant::*[contains(., $xpathliteral)]) = 0]";
 
         $found = $this->find_all('xpath', $xpath, false, $container);
         if (count($found) == 0) {
-            throw new ExpectationException('"'.$text.'" text was not found in the "'.$element.'" element', $this->getSession());
+            throw new ExpectationException('"' . $text . '" text was not found in the "' . $element .
+            '" element', $this->getSession());
         }
 
         foreach ($found as $node) {
@@ -238,8 +239,10 @@ class behat_auth_outage extends behat_base {
                 return;
             }
         }
-        throw new ExpectationException('"'.$text.'" text was found in the "'.$element.'" element but was not visible',
-            $this->getSession());
+        throw new ExpectationException(
+            '"' . $text . '" text was found in the "' . $element . '" element but was not visible',
+            $this->getSession()
+        );
     }
 
     /**
@@ -252,7 +255,7 @@ class behat_auth_outage extends behat_base {
         $locator = "#auth_outage_warningbar_box";
         $items = $this->getSession()->getPage()->findAll($selector, $locator);
         if (count($items) > 0) {
-            throw new ExpectationException($locator.' found, not expected.', $this->getSession());
+            throw new ExpectationException($locator . ' found, not expected.', $this->getSession());
         }
     }
 
@@ -280,7 +283,7 @@ class behat_auth_outage extends behat_base {
             $row
         );
         if (($row['autostart'] != 'yes') && ($row['autostart'] != 'no')) {
-            throw new Exception('autostart must be yes or no, found: '.$row['autostart']);
+            throw new Exception('autostart must be yes or no, found: ' . $row['autostart']);
         }
         if ($row['finished'] == '') {
             $row['finished'] = null;
@@ -318,7 +321,7 @@ class behat_auth_outage extends behat_base {
                 $seconds += 5; // Give it some extra time to pool the server.
                 break;
             default:
-                throw new Exception('Invalid $what='.$what);
+                throw new Exception('Invalid $what=' . $what);
         }
         if ($seconds >= 0) {
             $seconds++; // Give one extra second for things to happen.
@@ -332,7 +335,7 @@ class behat_auth_outage extends behat_base {
      */
     private function is_behat_3() {
         global $version;
-        list($behat) = explode('.', $version);
+        [$behat] = explode('.', $version);
         return ($behat >= 3);
     }
 }

--- a/tests/dml/installation_test.php
+++ b/tests/dml/installation_test.php
@@ -30,7 +30,7 @@ namespace auth_outage\dml;
 use auth_outage\local\outage;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/../base_testcase.php');
+require_once(__DIR__ . '/../base_testcase.php');
 
 /**
  * installation_test test class.
@@ -74,24 +74,33 @@ class installation_test extends \auth_outage\base_testcase {
         self::assertSame(1, $DB->count_records_select('event', "eventtype = 'auth_outage'", null));
 
         // Uninstall plugin.
-        require_once($CFG->libdir.'/adminlib.php');
+        require_once($CFG->libdir . '/adminlib.php');
         $progress = new \progress_trace_buffer(new \text_progress_trace(), false);
         \core_plugin_manager::instance()->uninstall_plugin('auth_outage', $progress);
         $progress->finished();
         self::assertStringContainsString('++ Success ++', $progress->get_buffer());
 
         // Check ...
-        self::assertSame(0, $DB->count_records_select('event', "eventtype = 'auth_outage'", null),
-            'The outage events were not removed.');
-        self::assertFalse(file_exists($CFG->dataroot.'/climaintenance.php'),
-            'The maintenance template file was not deleted.');
-        self::assertFalse(get_config('moodle', 'maintenance_later'),
-            'Maintenance later must not be set.'); // Issue #57.
-        self::assertFalse($dbman->table_exists('auth_outage'),
-            'Table "auth_outage" was not dropped.');
+        self::assertSame(
+            0,
+            $DB->count_records_select('event', "eventtype = 'auth_outage'", null),
+            'The outage events were not removed.'
+        );
+        self::assertFalse(
+            file_exists($CFG->dataroot . '/climaintenance.php'),
+            'The maintenance template file was not deleted.'
+        );
+        self::assertFalse(
+            get_config('moodle', 'maintenance_later'),
+            'Maintenance later must not be set.'
+        ); // Issue #57.
+        self::assertFalse(
+            $dbman->table_exists('auth_outage'),
+            'Table "auth_outage" was not dropped.'
+        );
 
         // Create tables back so tests do not fail with MySQL ...
-        require_once($CFG->libdir.'/upgradelib.php');
-        $DB->get_manager()->install_from_xmldb_file($CFG->dirroot.'/auth/outage/db/install.xml');
+        require_once($CFG->libdir . '/upgradelib.php');
+        $DB->get_manager()->install_from_xmldb_file($CFG->dirroot . '/auth/outage/db/install.xml');
     }
 }

--- a/tests/dml/outagedb_test.php
+++ b/tests/dml/outagedb_test.php
@@ -28,7 +28,7 @@ namespace auth_outage\dml;
 use auth_outage\local\outage;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/../base_testcase.php');
+require_once(__DIR__ . '/../base_testcase.php');
 
 /**
  * outagedb_test tests class.
@@ -112,7 +112,7 @@ class outagedb_test extends \auth_outage\base_testcase {
             $expected->createdby = $actual->createdby;
             $expected->modifiedby = $actual->modifiedby;
             // Check if fields are the same.
-            self::assertEquals($expected, $actual, 'Failed for $i='.$i);
+            self::assertEquals($expected, $actual, 'Failed for $i=' . $i);
         }
     }
 
@@ -204,7 +204,7 @@ class outagedb_test extends \auth_outage\base_testcase {
             self::assertNotNull($inserted);
             // Check its data.
             foreach (['starttime', 'stoptime', 'warntime', 'title', 'description'] as $field) {
-                self::assertSame($outage->$field, $inserted->$field, 'Field '.$field.' does not match.');
+                self::assertSame($outage->$field, $inserted->$field, 'Field ' . $field . ' does not match.');
             }
             // Check generated data.
             self::assertGreaterThan(0, $inserted->id);
@@ -212,11 +212,11 @@ class outagedb_test extends \auth_outage\base_testcase {
             self::assertNotNull($inserted->createdby);
             self::assertNotNull($inserted->modifiedby);
             // Change it.
-            $inserted->title = 'Title ID'.$id;
+            $inserted->title = 'Title ID' . $id;
             outagedb::save($inserted);
             // Get it again and check data.
             $updated = outagedb::get_by_id($id);
-            self::assertSame('Title ID'.$id, $updated->title);
+            self::assertSame('Title ID' . $id, $updated->title);
             self::assertSame($inserted->description, $updated->description);
             // Delete it.
             outagedb::delete($id);
@@ -255,8 +255,14 @@ class outagedb_test extends \auth_outage\base_testcase {
         self::saveoutage(false, $now, -2, 0, 0, 'Invalid outage.');
         self::assertSame($activeid, outagedb::get_active($now)->id, 'Wrong active outage picked.');
 
-        self::saveoutage(false, $now, -1, 2, 3,
-            'Another outage in warning period, but ignored as it starts after the previous one.');
+        self::saveoutage(
+            false,
+            $now,
+            -1,
+            2,
+            3,
+            'Another outage in warning period, but ignored as it starts after the previous one.'
+        );
         self::assertSame($activeid, outagedb::get_active($now)->id, 'Wrong active outage picked.');
 
         self::saveoutage(false, $now, -3, -2, 2, 'An finished outage.', -1);
@@ -268,8 +274,14 @@ class outagedb_test extends \auth_outage\base_testcase {
         self::saveoutage(false, $now, -3, -1, 1, 'Another ongoing outage but ignored because it started after the previous one.');
         self::assertSame($activeid, outagedb::get_active($now)->id, 'Wrong active outage picked.');
 
-        self::saveoutage(false, $now, -3, -2, 1,
-            'Another ongoing outage starting at the same time, but ignored as it stops before the previous one.');
+        self::saveoutage(
+            false,
+            $now,
+            -3,
+            -2,
+            1,
+            'Another ongoing outage starting at the same time, but ignored as it stops before the previous one.'
+        );
         self::assertSame($activeid, outagedb::get_active($now)->id, 'Wrong active outage picked.');
     }
 
@@ -292,36 +304,60 @@ class outagedb_test extends \auth_outage\base_testcase {
         self::assertEquals([], outagedb::get_all_unended($now), 'No future outages yet.');
 
         $id1 = self::saveoutage(false, $now, 2, 3, 4, 'A future outage.');
-        self::assertEquals([$id1],
-            self::createidarray(outagedb::get_all_unended($now)), 'Wrong future data.');
+        self::assertEquals(
+            [$id1],
+            self::createidarray(outagedb::get_all_unended($now)),
+            'Wrong future data.'
+        );
 
         $id2 = self::saveoutage(false, $now, 1, 4, 5, 'Another future outage.');
-        self::assertEquals([$id1, $id2],
-            self::createidarray(outagedb::get_all_unended($now)), 'Wrong future data.');
+        self::assertEquals(
+            [$id1, $id2],
+            self::createidarray(outagedb::get_all_unended($now)),
+            'Wrong future data.'
+        );
 
         $id3 = self::saveoutage(false, $now, 1, 3, 5, 'Yet another future outage.');
-        self::assertEquals([$id3, $id1, $id2],
-            self::createidarray(outagedb::get_all_unended($now)), 'Wrong future data.');
+        self::assertEquals(
+            [$id3, $id1, $id2],
+            self::createidarray(outagedb::get_all_unended($now)),
+            'Wrong future data.'
+        );
 
         $id4 = self::saveoutage(false, $now, -2, 1, 2, 'An outage in warning period.');
-        self::assertEquals([$id4, $id3, $id1, $id2],
-            self::createidarray(outagedb::get_all_unended($now)), 'Wrong future data.');
+        self::assertEquals(
+            [$id4, $id3, $id1, $id2],
+            self::createidarray(outagedb::get_all_unended($now)),
+            'Wrong future data.'
+        );
 
         $id5 = self::saveoutage(false, $now, -1, 2, 3, 'Another outage in warning period.');
-        self::assertEquals([$id4, $id5, $id3, $id1, $id2],
-            self::createidarray(outagedb::get_all_unended($now)), 'Wrong future data.');
+        self::assertEquals(
+            [$id4, $id5, $id3, $id1, $id2],
+            self::createidarray(outagedb::get_all_unended($now)),
+            'Wrong future data.'
+        );
 
         $id6 = self::saveoutage(false, $now, -3, -2, 2, 'An ongoing outage.');
-        self::assertEquals([$id6, $id4, $id5, $id3, $id1, $id2],
-            self::createidarray(outagedb::get_all_unended($now)), 'Wrong future data.');
+        self::assertEquals(
+            [$id6, $id4, $id5, $id3, $id1, $id2],
+            self::createidarray(outagedb::get_all_unended($now)),
+            'Wrong future data.'
+        );
 
         $id7 = self::saveoutage(false, $now, -3, -1, 1, 'Another ongoing outage.');
-        self::assertEquals([$id6, $id7, $id4, $id5, $id3, $id1, $id2],
-            self::createidarray(outagedb::get_all_unended($now)), 'Wrong future data.');
+        self::assertEquals(
+            [$id6, $id7, $id4, $id5, $id3, $id1, $id2],
+            self::createidarray(outagedb::get_all_unended($now)),
+            'Wrong future data.'
+        );
 
         $id8 = self::saveoutage(false, $now, -3, -2, 1, 'Yet another ongoing outage.');
-        self::assertEquals([$id6, $id8, $id7, $id4, $id5, $id3, $id1, $id2],
-            self::createidarray(outagedb::get_all_unended($now)), 'Wrong future data.');
+        self::assertEquals(
+            [$id6, $id8, $id7, $id4, $id5, $id3, $id1, $id2],
+            self::createidarray(outagedb::get_all_unended($now)),
+            'Wrong future data.'
+        );
     }
 
     /**
@@ -346,20 +382,32 @@ class outagedb_test extends \auth_outage\base_testcase {
         self::assertEquals([], outagedb::get_all_ended($now), 'No past outages yet.');
 
         $id1 = self::saveoutage(false, $now, -8, -6, -4, 'A past outage.');
-        self::assertEquals([$id1],
-            self::createidarray(outagedb::get_all_ended($now)), 'Wrong past data.');
+        self::assertEquals(
+            [$id1],
+            self::createidarray(outagedb::get_all_ended($now)),
+            'Wrong past data.'
+        );
 
         $id2 = self::saveoutage(false, $now, -8, -7, -5, 'Another past outage.');
-        self::assertEquals([$id1, $id2],
-            self::createidarray(outagedb::get_all_ended($now)), 'Wrong past data.');
+        self::assertEquals(
+            [$id1, $id2],
+            self::createidarray(outagedb::get_all_ended($now)),
+            'Wrong past data.'
+        );
 
         $id3 = self::saveoutage(false, $now, -8, -5, -3, 'Yet another past outage.');
-        self::assertEquals([$id3, $id1, $id2],
-            self::createidarray(outagedb::get_all_ended($now)), 'Wrong past data.');
+        self::assertEquals(
+            [$id3, $id1, $id2],
+            self::createidarray(outagedb::get_all_ended($now)),
+            'Wrong past data.'
+        );
 
         $id4 = self::saveoutage(false, $now, -3, -2, 2, 'A finished outage.', -1);
-        self::assertEquals([$id4, $id3, $id1, $id2],
-            self::createidarray(outagedb::get_all_ended($now)), 'Wrong past data.');
+        self::assertEquals(
+            [$id4, $id3, $id1, $id2],
+            self::createidarray(outagedb::get_all_ended($now)),
+            'Wrong past data.'
+        );
     }
 
     /**
@@ -493,7 +541,7 @@ class outagedb_test extends \auth_outage\base_testcase {
             'starttime' => $i * 100,
             'stoptime' => $i * 100 + 50,
             'warntime' => $i * 60,
-            'title' => 'The Title '.$i,
+            'title' => 'The Title ' . $i,
             'description' => 'A <b>description</b> in HTML.',
         ]);
     }

--- a/tests/form/outage/forms_test.php
+++ b/tests/form/outage/forms_test.php
@@ -28,7 +28,7 @@ namespace auth_outage\form\outage;
 use auth_outage\local\outage;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/../../base_testcase.php');
+require_once(__DIR__ . '/../../base_testcase.php');
 
 /**
  * forms_test test class.
@@ -127,8 +127,8 @@ class forms_test extends \auth_outage\base_testcase {
         }
 
         $this->mock_edit_post();
-        $_POST['title'] = 'This is a very long time, it is so long that at some point it should not be valid. '.
-                          'With a very long title used in this place we should get a form validation error. '.
+        $_POST['title'] = 'This is a very long time, it is so long that at some point it should not be valid. ' .
+                          'With a very long title used in this place we should get a form validation error. ' .
                           'Do you think this title is long enough?';
         $edit = new edit();
         self::assertNull($edit->get_data());
@@ -208,7 +208,7 @@ class forms_test extends \auth_outage\base_testcase {
         // The bugfix MDL-56250 in only applies to Moodle 30+.
         // Before that the form validation test is meaningless (results are cached), so skip it.
         if ($CFG->branch < 30) {
-            $this->markTestSkipped('Some tests can only run in Moodle 30+. '.$reason);
+            $this->markTestSkipped('Some tests can only run in Moodle 30+. ' . $reason);
             return true;
         }
 

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -17,8 +17,8 @@
 namespace auth_outage;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/base_testcase.php');
-require_once(__DIR__.'/../lib.php');
+require_once(__DIR__ . '/base_testcase.php');
+require_once(__DIR__ . '/../lib.php');
 
 /**
  * tests for lib.php
@@ -35,11 +35,11 @@ class lib_test extends base_testcase {
      */
     public function test_auth_outage_get_climaintenance_resource_file_resolves_a_file() {
         global $CFG;
-        $dir = $CFG->dataroot.'/auth_outage/climaintenance';
+        $dir = $CFG->dataroot . '/auth_outage/climaintenance';
         mkdir($dir, 0777, true);
 
         // Create a file.
-        $expected = $dir.'/example.txt';
+        $expected = $dir . '/example.txt';
         file_put_contents($expected, 'Outage Unit Test Message');
 
         // Get that file.
@@ -59,13 +59,13 @@ class lib_test extends base_testcase {
         global $CFG;
 
         // Create a file.
-        $realdir = $CFG->dataroot.'/auth_outage/climaintenance_real';
+        $realdir = $CFG->dataroot . '/auth_outage/climaintenance_real';
         mkdir($realdir, 0777, true);
-        $realfile = $realdir.'/example.txt';
+        $realfile = $realdir . '/example.txt';
         file_put_contents($realfile, 'Outage Unit Test Message');
 
         // Create a symlink.
-        $symdir = $CFG->dataroot.'/auth_outage/climaintenance';
+        $symdir = $CFG->dataroot . '/auth_outage/climaintenance';
         if (!symlink($realdir, $symdir)) {
             unlink($realfile);
             rmdir($realdir);
@@ -90,15 +90,15 @@ class lib_test extends base_testcase {
     public function test_auth_outage_get_climaintenance_resource_file_prevent_path_traversal() {
         global $CFG;
 
-        $dir = $CFG->dataroot.'/auth_outage/climaintenance';
+        $dir = $CFG->dataroot . '/auth_outage/climaintenance';
         mkdir($dir, 0777, true);
 
         // Create a file.
-        $expected = $dir.'/example.txt';
+        $expected = $dir . '/example.txt';
         file_put_contents($expected, 'Outage Unit Test Message');
 
         // Create a sensitive file.
-        $sensitivefile = $CFG->dataroot.'/auth_outage/nuclear_silo_passwords.txt';
+        $sensitivefile = $CFG->dataroot . '/auth_outage/nuclear_silo_passwords.txt';
         file_put_contents($sensitivefile, 'The password to launch the ICBM: 123456');
 
         // Path Traversal Attack.

--- a/tests/local/cli/cli_test.php
+++ b/tests/local/cli/cli_test.php
@@ -26,7 +26,7 @@
 namespace auth_outage\local\cli;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/cli_testcase.php');
+require_once(__DIR__ . '/cli_testcase.php');
 
 /**
  * cli_test test class.

--- a/tests/local/cli/cli_testcase.php
+++ b/tests/local/cli/cli_testcase.php
@@ -26,7 +26,7 @@
 namespace auth_outage\local\cli;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/../../base_testcase.php');
+require_once(__DIR__ . '/../../base_testcase.php');
 
 /**
  * cli_testcase class.

--- a/tests/local/cli/create_test.php
+++ b/tests/local/cli/create_test.php
@@ -29,7 +29,7 @@ use auth_outage\dml\outagedb;
 use auth_outage\local\outage;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/cli_testcase.php');
+require_once(__DIR__ . '/cli_testcase.php');
 
 /**
  * create_test test class.
@@ -255,7 +255,7 @@ class create_test extends cli_testcase {
         $this->set_parameters([
             '--onlyid',
             '--start=60',
-            '--clone='.$id,
+            '--clone=' . $id,
         ]);
         $cli = new create();
         $cli->set_referencetime($now);

--- a/tests/local/cli/finish_test.php
+++ b/tests/local/cli/finish_test.php
@@ -29,7 +29,7 @@ use auth_outage\dml\outagedb;
 use auth_outage\local\outage;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/cli_testcase.php');
+require_once(__DIR__ . '/cli_testcase.php');
 
 /**
  * finish_test test class.
@@ -100,7 +100,7 @@ class finish_test extends cli_testcase {
             'title' => 'Title',
             'description' => 'Description',
         ]));
-        $this->set_parameters(['-id='.$id]);
+        $this->set_parameters(['-id=' . $id]);
         $cli = new finish();
         $cli->set_referencetime($now);
         $this->set_expected_cli_exception(cli_exception::ERROR_OUTAGE_INVALID);
@@ -121,7 +121,7 @@ class finish_test extends cli_testcase {
             'title' => 'Title',
             'description' => 'Description',
         ]));
-        $this->set_parameters(['-id='.$id]);
+        $this->set_parameters(['-id=' . $id]);
         $cli = new finish();
         $cli->set_referencetime($now);
         $this->execute($cli);

--- a/tests/local/cli/waitforit_test.php
+++ b/tests/local/cli/waitforit_test.php
@@ -29,7 +29,7 @@ use auth_outage\dml\outagedb;
 use auth_outage\local\outage;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/cli_testcase.php');
+require_once(__DIR__ . '/cli_testcase.php');
 
 /**
  * waitforit_test test class.
@@ -127,7 +127,7 @@ class waitforit_test extends cli_testcase {
             'title' => 'Title',
             'description' => 'Description',
         ]));
-        $this->set_parameters(['-id='.$id]);
+        $this->set_parameters(['-id=' . $id]);
         $cli = new waitforit();
         $cli->set_referencetime($now);
         $this->set_expected_cli_exception(cli_exception::ERROR_OUTAGE_INVALID);

--- a/tests/local/controllers/infopage_test.php
+++ b/tests/local/controllers/infopage_test.php
@@ -29,7 +29,7 @@ use auth_outage\local\outage;
 use context_system;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/../../base_testcase.php');
+require_once(__DIR__ . '/../../base_testcase.php');
 
 /**
  * Tests performed on infopage controller class and update_static_page task class.

--- a/tests/local/controllers/maintenance_static_page_test.php
+++ b/tests/local/controllers/maintenance_static_page_test.php
@@ -29,7 +29,7 @@ use auth_outage\task\update_static_page;
 use DOMDocument;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/../../base_testcase.php');
+require_once(__DIR__ . '/../../base_testcase.php');
 
 /**
  * maintenance_static_page_test class.
@@ -47,10 +47,12 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
     public function test_templatefile() {
         global $CFG;
         $page = maintenance_static_page::create_from_html('<html></html>');
-        self::assertSame($CFG->dataroot.'/climaintenance.template.html', $page->get_io()->get_template_file());
+        self::assertSame($CFG->dataroot . '/climaintenance.template.html', $page->get_io()->get_template_file());
         $page->get_io()->set_preview(true);
-        self::assertSame($CFG->dataroot.'/auth_outage/climaintenance/preview/climaintenance.html',
-            $page->get_io()->get_template_file());
+        self::assertSame(
+            $CFG->dataroot . '/auth_outage/climaintenance/preview/climaintenance.html',
+            $page->get_io()->get_template_file()
+        );
     }
 
     /**
@@ -59,9 +61,9 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
     public function test_resourcesfolder() {
         global $CFG;
         $page = maintenance_static_page::create_from_html('<html></html>');
-        self::assertSame($CFG->dataroot.'/auth_outage/climaintenance', $page->get_io()->get_resources_folder());
+        self::assertSame($CFG->dataroot . '/auth_outage/climaintenance', $page->get_io()->get_resources_folder());
         $page->get_io()->set_preview(true);
-        self::assertSame($CFG->dataroot.'/auth_outage/climaintenance/preview', $page->get_io()->get_resources_folder());
+        self::assertSame($CFG->dataroot . '/auth_outage/climaintenance/preview', $page->get_io()->get_resources_folder());
     }
 
     /**
@@ -76,7 +78,7 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_createfromhtml() {
         $html = "<!DOCTYPE html>\n<html><head><title>Title</title></head><body>Content</body></html>";
-        $expected = "<!DOCTYPE html>\n<html><head><title>Title</title><meta http-equiv=\"refresh\" content=\"300\">".
+        $expected = "<!DOCTYPE html>\n<html><head><title>Title</title><meta http-equiv=\"refresh\" content=\"300\">" .
                     "</head><body>Content</body></html>";
         self::assertSame($expected, $this->generated_page_html($html));
     }
@@ -85,8 +87,8 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      * Test remove script tags.
      */
     public function test_removescripttags() {
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><script type="text/javascript" src="http://xyz"></script><title>Title</title></head>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><script type="text/javascript" src="http://xyz"></script><title>Title</title></head>' .
                 '<body>Content<script> a < 5; x > 3</script></body></html>';
         maintenance_static_page::create_from_html($html)->generate();
 
@@ -100,9 +102,9 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
     public function test_updatelinkstylesheet() {
         $localcsslink = $this->get_fixture_path_location('simple.css');
         $externalcsslink = 'http://google.com/coolstuff.css';
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><link href="'.$localcsslink.'" rel="stylesheet" /><title>Title</title></head>'.
-                '<body>Content<link rel="stylesheet" href="'.$externalcsslink.'"></body></html>';
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><link href="' . $localcsslink . '" rel="stylesheet" /><title>Title</title></head>' .
+                '<body>Content<link rel="stylesheet" href="' . $externalcsslink . '"></body></html>';
         $generated = $this->generated_page_html($html);
 
         self::assertStringContainsString('www.example.com/moodle/auth/outage/file.php?file=', $generated);
@@ -115,17 +117,19 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_updatelinkstylesheet_urls() {
         $localcsslink = $this->get_fixture_path_location('withurls.css');
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><link href="'.$localcsslink.'" rel="stylesheet" /><title>Title</title></head>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><link href="' . $localcsslink . '" rel="stylesheet" /><title>Title</title></head>' .
                 '<body>Content</body></html>';
         $page = maintenance_static_page::create_from_html($html);
         $page->generate();
 
         // Check for css file.
-        self::assertFileExists($page->get_io()->get_resources_folder().'/53365950336b070c0b26ca50e7d0dad962c364e6.dGV4dC9wbGFpbg');
+        self::assertFileExists($page->get_io()->get_resources_folder() .
+        '/53365950336b070c0b26ca50e7d0dad962c364e6.dGV4dC9wbGFpbg');
 
         // Check for catalyst.png file referenced in url(..) of css.
-        self::assertFileExists($page->get_io()->get_resources_folder().'/ff7f7f87a26a908fc72930eaefb6b57306361d16.aW1hZ2UvcG5n');
+        self::assertFileExists($page->get_io()->get_resources_folder() .
+        '/ff7f7f87a26a908fc72930eaefb6b57306361d16.aW1hZ2UvcG5n');
     }
 
     /**
@@ -133,17 +137,19 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_updatelinkstylesheet_urls_quoted() {
         $localcsslink = $this->get_fixture_path_location('withurls-quoted.css');
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><link href="'.$localcsslink.'" rel="stylesheet" /><title>Title</title></head>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><link href="' . $localcsslink . '" rel="stylesheet" /><title>Title</title></head>' .
                 '<body>Content</body></html>';
         $page = maintenance_static_page::create_from_html($html);
         $page->generate();
 
         // Check for css file.
-        self::assertFileExists($page->get_io()->get_resources_folder().'/e0b34925c1f939c247a4b50d6bf08c76088def39.dGV4dC9wbGFpbg');
+        self::assertFileExists($page->get_io()->get_resources_folder()
+        . '/e0b34925c1f939c247a4b50d6bf08c76088def39.dGV4dC9wbGFpbg');
 
         // Check for catalyst.png file referenced in url(..) of css.
-        self::assertFileExists($page->get_io()->get_resources_folder().'/ff7f7f87a26a908fc72930eaefb6b57306361d16.aW1hZ2UvcG5n');
+        self::assertFileExists($page->get_io()->get_resources_folder()
+        . '/ff7f7f87a26a908fc72930eaefb6b57306361d16.aW1hZ2UvcG5n');
     }
 
     /**
@@ -151,17 +157,19 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_updatelinkstylesheet_urls_subdir() {
         $localcsslink = $this->get_fixture_path_location('subdir/withurls-subdir.css');
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><link href="'.$localcsslink.'" rel="stylesheet" /><title>Title</title></head>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><link href="' . $localcsslink . '" rel="stylesheet" /><title>Title</title></head>' .
                 '<body>Content</body></html>';
         $page = maintenance_static_page::create_from_html($html);
         $page->generate();
 
         // Check for css file.
-        self::assertFileExists($page->get_io()->get_resources_folder().'/beb44281e23b9d872056bf0230cea34535e8cdea.dGV4dC9wbGFpbg');
+        self::assertFileExists($page->get_io()->get_resources_folder() .
+        '/beb44281e23b9d872056bf0230cea34535e8cdea.dGV4dC9wbGFpbg');
 
         // Check for file referenced in url(..) of css.
-        self::assertFileExists($page->get_io()->get_resources_folder().'/a02a8a442fa82d5205ffb24722d9df7f35161f56.dGV4dC9wbGFpbg');
+        self::assertFileExists($page->get_io()->get_resources_folder() .
+        '/a02a8a442fa82d5205ffb24722d9df7f35161f56.dGV4dC9wbGFpbg');
     }
 
      /**
@@ -170,9 +178,9 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
     public function test_updateimages() {
         $localimglink = $this->get_fixture_path_location('catalyst.png');
         $externalimglink = 'http://google.com/coolstyle.css';
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><title>Title</title></head>'.
-                '<body><img src="'.$localimglink.'">Content<img src="'.$externalimglink.'" /></body></html>';
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><title>Title</title></head>' .
+                '<body><img src="' . $localimglink . '">Content<img src="' . $externalimglink . '" /></body></html>';
         $generated = $this->generated_page_html($html);
 
         self::assertStringContainsString('www.example.com/moodle/auth/outage/file.php?file=', $generated);
@@ -185,8 +193,8 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
       */
     public function test_updatelinkfavicon() {
         $link = $this->get_fixture_path_location('catalyst.png');
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><title>Title</title><link rel="shortcut icon" href="'.$link.'""></head>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><title>Title</title><link rel="shortcut icon" href="' . $link . '""></head>' .
                 '<body>Content</body></html>';
         $generated = $this->generated_page_html($html);
 
@@ -229,9 +237,9 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
         $this->resetAfterTest(true);
         $generator = new maintenance_static_page_generator(new DOMDocument(), new maintenance_static_page_io());
 
-        $html = '<!DOCTYPE html>\n'.
-            '<html><head><title>Title</title></head>'.
-            '<body><div style="'.$stylecontent.'">Content</div></body></html>';
+        $html = '<!DOCTYPE html>\n' .
+            '<html><head><title>Title</title></head>' .
+            '<body><div style="' . $stylecontent . '">Content</div></body></html>';
 
         // Temporarily disable debugging to prevent errors because file does not exist.
         $debuglevel = $CFG->debug;
@@ -254,8 +262,8 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
       */
     public function test_previewpath() {
         $link = $this->get_fixture_path_location('catalyst.png');
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><title>Title</title><link rel="shortcut icon" href="'.$link.'""></head>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><title>Title</title><link rel="shortcut icon" href="' . $link . '""></head>' .
                 '<body>Content</body></html>';
         $page = maintenance_static_page::create_from_html($html);
         $page->get_io()->set_preview(true);
@@ -295,7 +303,7 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_updatestaticpage_hasfile() {
         global $CFG;
-        $file = $CFG->dataroot.'/climaintenance.template.html';
+        $file = $CFG->dataroot . '/climaintenance.template.html';
         touch($file);
         self::assertFileExists($file);
         maintenance_static_page::create_from_outage(null)->generate();
@@ -314,19 +322,19 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
         global $CFG;
 
         $link = $this->get_fixture_path_location('catalyst.png');
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><title>Title</title></head>'.
-                '<body>Content<img src="'.$link.'" /></body></html>';
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><title>Title</title></head>' .
+                '<body>Content<img src="' . $link . '" /></body></html>';
         $page = maintenance_static_page::create_from_html($html);
         $page->generate();
 
         // This checks if content is correct and mime type is correct from the encoded name.
-        $file = $page->get_io()->get_resources_folder().'/ff7f7f87a26a908fc72930eaefb6b57306361d16.aW1hZ2UvcG5n';
+        $file = $page->get_io()->get_resources_folder() . '/ff7f7f87a26a908fc72930eaefb6b57306361d16.aW1hZ2UvcG5n';
         self::assertFileExists($file);
 
         // We can still assert the contents really match, not just the hash.
         $found = file_get_contents($file);
-        $expected = file_get_contents(__DIR__.'/fixtures/catalyst.png');
+        $expected = file_get_contents(__DIR__ . '/fixtures/catalyst.png');
         self::assertSame($found, $expected);
     }
 
@@ -338,7 +346,7 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      * @return string
      */
     private function get_fixture_path_location($file) {
-        return (string)new \moodle_url('/auth/outage/tests/local/controllers/fixtures/'.$file);
+        return (string)new \moodle_url('/auth/outage/tests/local/controllers/fixtures/' . $file);
     }
 
     /**
@@ -398,7 +406,7 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      * Test file get_data.
      */
     public function test_file_get_data() {
-        $file = __DIR__.'/fixtures/catalyst.png';
+        $file = __DIR__ . '/fixtures/catalyst.png';
         $found = maintenance_static_page_io::file_get_data($file);
         self::assertSame(file_get_contents($file), $found['contents']);
         self::assertSame('image/png', $found['mime']);
@@ -408,7 +416,7 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      * Test invalid file get_data.
      */
     public function test_file_get_data_invalidfile() {
-        $found = maintenance_static_page_io::file_get_data(__DIR__.'/fixtures/invalidfile');
+        $found = maintenance_static_page_io::file_get_data(__DIR__ . '/fixtures/invalidfile');
         self::assertSame('', $found['contents']);
         self::assertSame('unknown', $found['mime']);
         self::assertCount(1, $this->getDebuggingMessages());
@@ -444,7 +452,9 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
         self::assertSame(0, $curl->get_errno());
         if ($CFG->branch >= 403) {
             self::assertDebuggingCalled(
-                "Blocked $testhtml: The URL is blocked. [user {$USER->id}]", DEBUG_NONE);
+                "Blocked $testhtml: The URL is blocked. [user {$USER->id}]",
+                DEBUG_NONE
+            );
         }
 
         // Test file_get_data does return the page and isn't blocked by security.
@@ -459,8 +469,8 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_remove_css_selector() {
         $this->resetAfterTest(true);
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><title>Title</title></head>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><title>Title</title></head>' .
                 '<body>Content<b class="removeme">Goodbye cruel world.</b></body></html>';
         set_config('remove_selectors', '.removeme', 'auth_outage');
         $generated = $this->generated_page_html($html);
@@ -474,8 +484,8 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_remove_css_selector_id() {
         $this->resetAfterTest(true);
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><title>Title</title></head>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><title>Title</title></head>' .
                 '<body>Content<b id="removeme">Goodbye cruel world.</b></body></html>';
         set_config('remove_selectors', '#removeme', 'auth_outage');
         $generated = $this->generated_page_html($html);
@@ -489,11 +499,11 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_remove_css_selector_with_multiline() {
         $this->resetAfterTest(true);
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><title>Title</title></head>'.
-                '<body>'.
-                '<b class="deleteme">Goodbye cruel world.</b>'.
-                '<b class="removeme">Goodbye cruel world.</b>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><title>Title</title></head>' .
+                '<body>' .
+                '<b class="deleteme">Goodbye cruel world.</b>' .
+                '<b class="removeme">Goodbye cruel world.</b>' .
                 '</body></html>';
         set_config('remove_selectors', ".removeme\n.deleteme", 'auth_outage');
         $generated = $this->generated_page_html($html);
@@ -508,11 +518,11 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_remove_css_selector_needing_trim() {
         $this->resetAfterTest(true);
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><title>Title</title></head>'.
-                '<body>'.
-                '<b class="deleteme">Goodbye cruel world.</b>'.
-                '<b class="removeme">Goodbye cruel world.</b>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><title>Title</title></head>' .
+                '<body>' .
+                '<b class="deleteme">Goodbye cruel world.</b>' .
+                '<b class="removeme">Goodbye cruel world.</b>' .
                 '</body></html>';
         set_config('remove_selectors', " .removeme     \n    .deleteme   ", 'auth_outage');
         $generated = $this->generated_page_html($html);
@@ -527,11 +537,11 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_remove_css_selector_with_empty_line() {
         $this->resetAfterTest(true);
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><title>Title</title></head>'.
-                '<body>'.
-                '<b class="deleteme">Goodbye cruel world.</b>'.
-                '<b class="removeme">Goodbye cruel world.</b>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><title>Title</title></head>' .
+                '<body>' .
+                '<b class="deleteme">Goodbye cruel world.</b>' .
+                '<b class="removeme">Goodbye cruel world.</b>' .
                 '</body></html>';
         set_config('remove_selectors', "\n\n.removeme\n\n\n\n.deleteme\n\n", 'auth_outage');
         $generated = $this->generated_page_html($html);
@@ -546,8 +556,8 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_remove_css_selector_with_invalid_id() {
         $this->resetAfterTest(true);
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><title>Title</title></head>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><title>Title</title></head>' .
                 '<body>Content<b id="removeme">Goodbye cruel world.</b></body></html>';
         set_config('remove_selectors', '#invalidid', 'auth_outage');
         $generated = $this->generated_page_html($html);
@@ -561,8 +571,8 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_meta_refresh_5minutes() {
         $this->resetAfterTest(true);
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><title>Title</title></head>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><title>Title</title></head>' .
                 '<body>Content<b id="removeme">Goodbye cruel world.</b></body></html>';
         set_config('remove_selectors', '#invalidid', 'auth_outage');
         $generated = $this->generated_page_html($html);
@@ -575,8 +585,8 @@ class maintenance_static_page_test extends \auth_outage\base_testcase {
      */
     public function test_meta_refresh_maximum_5seconds() {
         $this->resetAfterTest(true);
-        $html = "<!DOCTYPE html>\n".
-                '<html><head><title>Title</title></head>'.
+        $html = "<!DOCTYPE html>\n" .
+                '<html><head><title>Title</title></head>' .
                 '<body>Content<b id="removeme">Goodbye cruel world.</b></body></html>';
         set_config('remove_selectors', '#invalidid', 'auth_outage');
         $page = maintenance_static_page::create_from_html($html);

--- a/tests/local/outage_test.php
+++ b/tests/local/outage_test.php
@@ -17,7 +17,7 @@
 namespace auth_outage\local;
 
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/../base_testcase.php');
+require_once(__DIR__ . '/../base_testcase.php');
 
 /**
  * outage_test test class.

--- a/tests/local/outagelib_test.php
+++ b/tests/local/outagelib_test.php
@@ -20,8 +20,8 @@ use auth_outage\dml\outagedb;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
-require_once($CFG->libdir.'/adminlib.php');
-require_once(__DIR__.'/../base_testcase.php');
+require_once($CFG->libdir . '/adminlib.php');
+require_once(__DIR__ . '/../base_testcase.php');
 
 /**
  * outagelib_test test class.
@@ -215,12 +215,12 @@ class outagelib_test extends \auth_outage\base_testcase {
         ];
         // Set config with values.
         foreach ($keys as $k) {
-            set_config($k, $k.'_value', 'auth_outage');
+            set_config($k, $k . '_value', 'auth_outage');
         }
         // Ensure it is not using any defaults.
         $config = outagelib::get_config();
         foreach ($keys as $k) {
-            self::assertSame($config->$k, $k.'_value', 'auth_outage');
+            self::assertSame($config->$k, $k . '_value', 'auth_outage');
         }
 
         set_config('allowedips_forced', 'allowedips_forced_value', 'auth_outage');
@@ -461,7 +461,7 @@ EOT;
             'stoptime' => 456,
             'accesskey' => '5678',
         ]);
-        $file = $CFG->dataroot.'/climaintenance.php';
+        $file = $CFG->dataroot . '/climaintenance.php';
         set_config($configkey, '127.0.0.1', 'auth_outage');
 
         outagelib::update_climaintenance_code($outage);
@@ -490,7 +490,7 @@ EOT;
             'stoptime' => 456,
             'accesskey' => null,
         ]);
-        $file = $CFG->dataroot.'/climaintenance.php';
+        $file = $CFG->dataroot . '/climaintenance.php';
         set_config('allowedips', '', 'auth_outage');
         set_config('allowedips_forced', '', 'auth_outage');
 
@@ -509,7 +509,7 @@ EOT;
      */
     public function test_createmaintenancephpcode_withoutoutage() {
         global $CFG;
-        $file = $CFG->dataroot.'/climaintenance.php';
+        $file = $CFG->dataroot . '/climaintenance.php';
 
         touch($file);
         outagelib::update_climaintenance_code(null);
@@ -530,7 +530,7 @@ EOT;
         $this->create_outage();
 
         // The method outagelib::prepare_next_outage() should have been called by save().
-        foreach ([$CFG->dataroot.'/climaintenance.template.html', $CFG->dataroot.'/climaintenance.php'] as $file) {
+        foreach ([$CFG->dataroot . '/climaintenance.template.html', $CFG->dataroot . '/climaintenance.php'] as $file) {
             self::assertFileExists($file);
             unlink($file);
         }
@@ -548,7 +548,7 @@ EOT;
         set_config('s_auth_outage_allowedips', '127', 'auth_outage');
 
         // The method outagelib::prepare_next_outage() should have been called from admin_write_settings().
-        foreach ([$CFG->dataroot.'/climaintenance.template.html', $CFG->dataroot.'/climaintenance.php'] as $file) {
+        foreach ([$CFG->dataroot . '/climaintenance.template.html', $CFG->dataroot . '/climaintenance.php'] as $file) {
             self::assertFileExists($file);
             unlink($file);
         }
@@ -566,7 +566,7 @@ EOT;
         set_config('s_auth_outage_remove_selectors', '.something', 'auth_outage');
 
         // The method outagelib::prepare_next_outage() should have been called from admin_write_settings().
-        foreach ([$CFG->dataroot.'/climaintenance.template.html', $CFG->dataroot.'/climaintenance.php'] as $file) {
+        foreach ([$CFG->dataroot . '/climaintenance.template.html', $CFG->dataroot . '/climaintenance.php'] as $file) {
             self::assertFileExists($file);
             unlink($file);
         }
@@ -596,9 +596,9 @@ EOT;
         // This file should not exist even if the statement above fails as Moodle does not create it immediately but test anyway.
         // Backwards compatibility with older PHPUnit - use old assertFile method.
         if (method_exists($this, 'assertFileDoesNotExist')) {
-            self::assertFileDoesNotExist($CFG->dataroot.'/climaintenance.html');
+            self::assertFileDoesNotExist($CFG->dataroot . '/climaintenance.html');
         } else {
-            self::assertFileNotExists($CFG->dataroot.'/climaintenance.html');
+            self::assertFileNotExists($CFG->dataroot . '/climaintenance.html');
         }
     }
 
@@ -744,8 +744,13 @@ EOT;
      * see https://github.com/sebastianbergmann/phpunit/issues/720#issuecomment-10421092
      * @runInSeparateProcess
      */
-    public function test_evaluation_maintenancepage(?string $allowedips, ?string $iptouse, ?string $accesskey,
-        ?string $accesskeytouse, array $expectedoutputs) {
+    public function test_evaluation_maintenancepage(
+        ?string $allowedips,
+        ?string $iptouse,
+        ?string $accesskey,
+        ?string $accesskeytouse,
+        array $expectedoutputs
+    ) {
 
         global $CFG, $_SERVER, $_GET;
 
@@ -766,7 +771,7 @@ EOT;
             set_config('allowedips', $allowedips, 'auth_outage');
         }
         // Ensure if the file exists we clean it (e.g. from a previous test run).
-        $file = $CFG->dataroot.'/climaintenance.php';
+        $file = $CFG->dataroot . '/climaintenance.php';
         if (file_exists($file)) {
             unlink($file);
         }

--- a/views/info/content.php
+++ b/views/info/content.php
@@ -41,15 +41,17 @@ defined('MOODLE_INTERNAL') || die();
     </div>
     <div class="auth_outage_info_description"><?php echo $viewbag['outage']->get_description(); ?></div>
 
-    <?php if ($viewbag['admin']): ?>
+    <?php if ($viewbag['admin']) : ?>
         <?php
         $adminlinks = [];
-        foreach ([
+        foreach (
+            [
             'startofwarning' => -$viewbag['outage']->get_warning_duration(),
             '15secondsbefore' => -15,
             'start' => 0,
             'endofoutage' => $viewbag['outage']->get_duration_planned() - 1,
-        ] as $title => $delta) {
+            ] as $title => $delta
+        ) {
             $adminlinks[] = html_writer::link(
                 new moodle_url(
                     '/auth/outage/info.php',
@@ -59,7 +61,7 @@ defined('MOODLE_INTERNAL') || die();
                         'auth_outage_delta' => $delta,
                     ]
                 ),
-                get_string('info'.$title, 'auth_outage')
+                get_string('info' . $title, 'auth_outage')
             );
         }
         $adminlinks[] = html_writer::link(

--- a/views/manage.php
+++ b/views/manage.php
@@ -41,11 +41,11 @@ echo $viewbag['warning'];
 
 <section id="section_planned_outages">
     <?php echo $output->rendersubtitle('outageslistfuture'); ?>
-    <?php if (empty($viewbag['unended'])): ?>
+    <?php if (empty($viewbag['unended'])) : ?>
         <p>
             <small><?php echo get_string('notfound', 'auth_outage'); ?></small>
         </p>
-    <?php else: ?>
+    <?php else : ?>
         <?php
         $table = new planned_table();
         $table->show_data($viewbag['unended']);
@@ -65,7 +65,7 @@ echo $viewbag['warning'];
             $urlnew->param('starttime', $next);
             echo $output->single_button($urlnew, get_string('outagecreate', 'auth_outage'));
             if ($default) {
-                echo ' ' . userdate( $next, get_string('datetimeformat', 'auth_outage'));
+                echo ' ' . userdate($next, get_string('datetimeformat', 'auth_outage'));
             }
         }
     endif; ?>
@@ -73,11 +73,11 @@ echo $viewbag['warning'];
 
 <section id="section_outage_history">
     <?php echo $output->rendersubtitle('outageslistpast'); ?>
-    <?php if (empty($viewbag['ended'])): ?>
+    <?php if (empty($viewbag['ended'])) : ?>
         <p>
             <small><?php echo get_string('notfound', 'auth_outage'); ?></small>
         </p>
-    <?php else: ?>
+    <?php else : ?>
         <?php
         $table = new history_table();
         $table->show_data($viewbag['ended']);

--- a/views/warningbar/warningbar.php
+++ b/views/warningbar/warningbar.php
@@ -49,19 +49,25 @@ if (!$viewbag['static']) {
     if (is_siteadmin()) {
         $link = html_writer::link(
             new moodle_url('/auth/outage/finish.php', ['id' => $viewbag['outage']->id]),
-            $OUTPUT->pix_icon('t/check', get_string('finish', 'auth_outage'), 'moodle', array('class' => 'iconsmall')) . get_string('finish', 'auth_outage'),
+            $OUTPUT->pix_icon(
+                't/check',
+                get_string('finish', 'auth_outage'),
+                'moodle',
+                ['class' => 'iconsmall']
+            )
+                    . get_string('finish', 'auth_outage'),
             [
-                'title' => get_string('finish', 'auth_outage'),
-                'class' => 'auth_outage_warningbar_box_finish',
-            ]
+                    'title' => get_string('finish', 'auth_outage'),
+                    'class' => 'auth_outage_warningbar_box_finish',
+                    ]
         );
-        $title .= ' '.html_writer::span($link, '', ['id' => 'auth_outage_warningbar_button']);
+        $title .= ' ' . html_writer::span($link, '', ['id' => 'auth_outage_warningbar_button']);
     }
 }
 ?>
     <style>
         <?php
-            readfile($CFG->dirroot.'/auth/outage/views/warningbar/warningbar.css');
+            readfile($CFG->dirroot . '/auth/outage/views/warningbar/warningbar.css');
             echo outagelib::get_config()->css;
         ?>
     </style>
@@ -73,11 +79,11 @@ if (!$viewbag['static']) {
         </div>
     </div>
 
-<?php if (!$viewbag['static']): ?>
+<?php if (!$viewbag['static']) : ?>
     <script>
         document.body.className += ' auth_outage';
         <?php
-        require(__DIR__.'/warningbar.js');
+        require(__DIR__ . '/warningbar.js');
         $json = json_encode([
             'countdown' => $countdown,
             'ongoing' => $ongoing,
@@ -89,7 +95,7 @@ if (!$viewbag['static']) {
             'preview' => $viewbag['preview'],
             'checkfinishedurl' => (string)(new moodle_url('/auth/outage/checkfinished.php')),
         ]);
-        echo 'authOutageWarningBar.init('.$json.');';
+        echo 'authOutageWarningBar.init(' . $json . ');';
         ?>
     </script>
 <?php endif;


### PR DESCRIPTION
#390

## Summary
Fixed plugin code to adhere to coding standards.  The extend of the cleanup was just basic formatting and indentation fixes. `auth/outage/local/bootstrap.php` needed a change to the way it handled the `MOODLE_INTERNAL' constant.