### PR TITLE
Issue #390: fixed version.php plugin version, release and required moodle version.

### DIFF
--- a/version.php
+++ b/version.php
@@ -28,8 +28,9 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = "auth_outage";
-$plugin->version = 2026011300;                  // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release = 2026011300;                  // Human-readable release information.
-$plugin->requires = 2025100600;                 // Moodle 5.1.
-$plugin->maturity = MATURITY_STABLE;            // Suitable for PRODUCTION environments!
-$plugin->supported = [501, 501];                 // A range of branch numbers of supported moodle versions.
+$plugin->version = 2026011300;          // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release = 2026011300;          // Human-readable release information.
+$plugin->requires = 2025100600;         // Moodle 5.1.
+$plugin->maturity = MATURITY_STABLE;    // Suitable for PRODUCTION environments!
+$plugin->supported = [501, 501];        // A range of branch numbers of supported moodle versions.
+

--- a/version.php
+++ b/version.php
@@ -33,4 +33,3 @@ $plugin->release = 2026011300;          // Human-readable release information.
 $plugin->requires = 2025100600;         // Moodle 5.1.
 $plugin->maturity = MATURITY_STABLE;    // Suitable for PRODUCTION environments!
 $plugin->supported = [501, 501];        // A range of branch numbers of supported moodle versions.
-

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = "auth_outage";
-$plugin->version = 2024081900;                  // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release = 2024081900;                  // Human-readable release information.
-$plugin->requires = 2025091900;                 // Moodle 5.1.
+$plugin->version = 2026011300;                  // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release = 2026011300;                  // Human-readable release information.
+$plugin->requires = 2025100600;                 // Moodle 5.1.
 $plugin->maturity = MATURITY_STABLE;            // Suitable for PRODUCTION environments!
 $plugin->supported = [501, 501];                 // A range of branch numbers of supported moodle versions.


### PR DESCRIPTION
#390

## Summary

Changed the `$plugin->version` and `$plugin->release` to today's date and fixed `$plugin->requires` to have the correct number for Moodle 5.1.