### PR TITLE
Issue #390: Changed outage auto-start default parameter from checkbox to dropdown with option to fully disable.

### DIFF
--- a/classes/dml/outagedb.php
+++ b/classes/dml/outagedb.php
@@ -100,6 +100,12 @@ class outagedb {
         $outage->modifiedby = $USER->id;
         $outage->lastmodified = time();
 
+        // Setting autostart to false if the default autostart is configured to "Force off".
+        if (get_config('default_autostart', 'auth_outage') === '2') {
+            $outage->autostart = 0;
+        }
+
+
         if ($outage->id === null) {
             // If new outage, set its creator.
             $outage->createdby = $USER->id;

--- a/classes/dml/outagedb.php
+++ b/classes/dml/outagedb.php
@@ -105,7 +105,6 @@ class outagedb {
             $outage->autostart = 0;
         }
 
-
         if ($outage->id === null) {
             // If new outage, set its creator.
             $outage->createdby = $USER->id;

--- a/classes/form/outage/edit.php
+++ b/classes/form/outage/edit.php
@@ -48,8 +48,11 @@ class edit extends moodleform {
         $mform->addElement('hidden', 'id');
         $mform->setType('id', PARAM_INT);
 
-        $mform->addElement('checkbox', 'autostart', get_string('autostart', 'auth_outage'));
-        $mform->addHelpButton('autostart', 'autostart', 'auth_outage');
+
+        if (get_config('auth_outage', 'default_autostart') !== '2') {
+            $mform->addElement('checkbox', 'autostart', get_string('autostart', 'auth_outage'));
+            $mform->addHelpButton('autostart', 'autostart', 'auth_outage');
+        }
 
         $mform->addElement('duration', 'warningduration', get_string('warningduration', 'auth_outage'));
         $mform->addHelpButton('warningduration', 'warningduration', 'auth_outage');

--- a/classes/form/outage/edit.php
+++ b/classes/form/outage/edit.php
@@ -48,7 +48,6 @@ class edit extends moodleform {
         $mform->addElement('hidden', 'id');
         $mform->setType('id', PARAM_INT);
 
-
         if (get_config('auth_outage', 'default_autostart') !== '2') {
             $mform->addElement('checkbox', 'autostart', get_string('autostart', 'auth_outage'));
             $mform->addHelpButton('autostart', 'autostart', 'auth_outage');

--- a/classes/local/outagelib.php
+++ b/classes/local/outagelib.php
@@ -223,7 +223,7 @@ class outagelib {
      * @param outage|null $outage Outage or null if no scheduled outage.
      */
     private static function update_maintenance_later($outage) {
-        if (is_null($outage) || !$outage->autostart) {
+        if (is_null($outage) || !$outage->autostart || get_config('default_autostart', 'auth_outage') === '2') {
             unset_config('maintenance_later');
         } else {
             $message = get_config('moodle', 'maintenance_message');

--- a/lang/en/auth_outage.php
+++ b/lang/en/auth_outage.php
@@ -32,6 +32,8 @@ $string['allowedipsnoconfig'] = 'Your config.php does not have the extra setup t
 $string['auth_outagedescription'] = 'Auxiliary plugin that warns users about a future outage and prevents them from logging in once the outage starts.';
 $string['autostart'] = 'Auto start maintenance mode.';
 $string['autostart_help'] = 'If selected, when the outage starts it will automatically turn on Moodle maintenance mode.';
+$string['autostartoff'] = 'Default off';
+$string['autostarton'] = 'Default on';
 $string['builtinallowediplist'] = 'Builtin Allowed IP List';
 $string['builtinallowediplist_desc'] = 'A second allowed IP list which makes it easier to have some IPs forced in config.php and others editable in the UI';
 $string['clicreateexamples'] = "Create an outage starting in 10 seconds\n\n> php create.php -s=10";
@@ -99,6 +101,7 @@ $string['defaultwarningdurationdescription'] = 'Default warning time (in minutes
 $string['description'] = 'Public Description';
 $string['description_help'] = 'A full description of the outage, publicly visible by all users.';
 $string['finish'] = 'Finish';
+$string['forceoff'] = 'Force off';
 $string['info15secondsbefore'] = '15 seconds before';
 $string['infoendofoutage'] = 'end of outage';
 $string['infofrom'] = 'From:';

--- a/lang/en/auth_outage.php
+++ b/lang/en/auth_outage.php
@@ -34,6 +34,7 @@ $string['autostart'] = 'Auto start maintenance mode.';
 $string['autostart_help'] = 'If selected, when the outage starts it will automatically turn on Moodle maintenance mode.';
 $string['autostartoff'] = 'Default off';
 $string['autostarton'] = 'Default on';
+$string['autostartforcedoff'] = 'Force off';
 $string['builtinallowediplist'] = 'Builtin Allowed IP List';
 $string['builtinallowediplist_desc'] = 'A second allowed IP list which makes it easier to have some IPs forced in config.php and others editable in the UI';
 $string['clicreateexamples'] = "Create an outage starting in 10 seconds\n\n> php create.php -s=10";
@@ -101,7 +102,6 @@ $string['defaultwarningdurationdescription'] = 'Default warning time (in minutes
 $string['description'] = 'Public Description';
 $string['description_help'] = 'A full description of the outage, publicly visible by all users.';
 $string['finish'] = 'Finish';
-$string['forceoff'] = 'Force off';
 $string['info15secondsbefore'] = '15 seconds before';
 $string['infoendofoutage'] = 'end of outage';
 $string['infofrom'] = 'From:';

--- a/settings.php
+++ b/settings.php
@@ -43,11 +43,16 @@ if ($hassiteconfig) {
         get_string('settingssectiondefaultsdescription', 'auth_outage') . $description
     ));
 
-    $settings->add(new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configselect(
         'auth_outage/default_autostart',
         get_string('defaultoutageautostart', 'auth_outage'),
         get_string('defaultoutageautostartdescription', 'auth_outage'),
-        $defaults['default_autostart']
+        'off',
+        [
+            '0' => get_string('autostartoff', 'auth_outage'),
+            '1' => get_string('autostarton', 'auth_outage'),
+            '2' => get_string('forceoff', 'auth_outage'),
+        ]
     ));
 
     $settings->add(new admin_setting_configduration(

--- a/settings.php
+++ b/settings.php
@@ -47,11 +47,11 @@ if ($hassiteconfig) {
         'auth_outage/default_autostart',
         get_string('defaultoutageautostart', 'auth_outage'),
         get_string('defaultoutageautostartdescription', 'auth_outage'),
-        'off',
+        '0',
         [
             '0' => get_string('autostartoff', 'auth_outage'),
             '1' => get_string('autostarton', 'auth_outage'),
-            '2' => get_string('forceoff', 'auth_outage'),
+            '2' => get_string('autostartforcedoff', 'auth_outage'),
         ]
     ));
 

--- a/version.php
+++ b/version.php
@@ -30,6 +30,8 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->component = "auth_outage";
 $plugin->version = 2024081900;                  // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release = 2024081900;                  // Human-readable release information.
+$plugin->version = 2024081900;                  // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release = 2024081900;                  // Human-readable release information.
 $plugin->requires = 2017111309;                 // 2017111309 = T13, but this really requires 3.9 and higher.
 $plugin->maturity = MATURITY_STABLE;            // Suitable for PRODUCTION environments!
 $plugin->supported = [39, 405];                 // A range of branch numbers of supported moodle versions.

--- a/version.php
+++ b/version.php
@@ -28,10 +28,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = "auth_outage";
-$plugin->version = 2024081900;                  // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release = 2024081900;                  // Human-readable release information.
-$plugin->version = 2024081900;                  // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release = 2024081900;                  // Human-readable release information.
+$plugin->version = 2024081901;                  // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release = 2024081901;                  // Human-readable release information.
 $plugin->requires = 2017111309;                 // 2017111309 = T13, but this really requires 3.9 and higher.
 $plugin->maturity = MATURITY_STABLE;            // Suitable for PRODUCTION environments!
 $plugin->supported = [39, 405];                 // A range of branch numbers of supported moodle versions.


### PR DESCRIPTION
#390

 ## Summary

Converted the **auth_outage | default_autostart** setting from a checkbox to a drop down with an option to fully disable maintenance mode. The options for the drop down are:

- Default off (This is the default option)
- Default on
- Force off


## Before and After Images

**Before**:
<img width="1089" height="270" alt="image" src="https://github.com/user-attachments/assets/8b2c1c66-f704-4f40-9ab3-da037b2f65ca" />

**After**:
<img width="1141" height="316" alt="image" src="https://github.com/user-attachments/assets/f1663200-719f-49b8-a55a-82718a46e14e" />