### PR TITLE
issue #405: fix unit test failure

### DIFF
--- a/tests/local/controllers/maintenance_static_page_test.php
+++ b/tests/local/controllers/maintenance_static_page_test.php
@@ -459,8 +459,8 @@ final class maintenance_static_page_test extends \auth_outage\base_testcase {
 
         // Test file_get_data does return the page and isn't blocked by security.
         $found = maintenance_static_page_io::file_get_data($url->out());
-        $expected = '47250a973d1b88d9445f94db4ef2c97a';
-        self::assertSame($expected, md5($found['contents']));
+        $expected = 'Moodle is a software package for producing internet-based courses and web sites.';
+        self::assertStringContainsString($expected, $found['contents']);
         self::assertSame('text/html', $found['mime']);
     }
 

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = "auth_outage";
-$plugin->version = 2024081903;                  // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release = 2024081903;                  // Human-readable release information.
+$plugin->version = 2024081904;                  // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release = 2024081904;                  // Human-readable release information.
 $plugin->requires = 2017111309;                 // 2017111309 = T13, but this really requires 3.9 and higher.
 $plugin->maturity = MATURITY_STABLE;            // Suitable for PRODUCTION environments!
 $plugin->supported = [39, 405];                 // A range of branch numbers of supported moodle versions.


### PR DESCRIPTION
The test is using a test file from https://download.moodle.org/unittest/test.html

The URL uses Cloudflare, and it injects a tab into the body.

```
$ curl -I https://download.moodle.org/unittest/test.html | grep server
server: cloudflare
```

```
 $ curl https://download.moodle.org/unittest/test.html | grep cdn
  <body><a href="https://download.moodle.org/cdn-cgi/content?id=k2lZQnmKOS_ziBsl1zIe_7G_fltdL5LsdlHS2X4aJgw-1781672410.4668567-1.2.1.1-7yEeX9Hy.yVoimBASyb4wYED5nWylHdWCgVuWGIbdXY" aria-hidden="true" rel="nofollow noopener" style="display: none !important; visibility: hidden !important"></a>
```

We can't use md5 to check the content as the injected tag is always different.
Just check some strings for testing.