### PR TITLE
Fix outage step test by forcing login default to off

### DIFF
--- a/tests/base_testcase.php
+++ b/tests/base_testcase.php
@@ -95,6 +95,9 @@ abstract class base_testcase extends \advanced_testcase {
 
         parent::setUp();
         $this->resetAfterTest(true);
+
+        // These tests rely on force login being disabled, but Moodle 5.2 enables it by default (MDL-87523).
+        set_config('forcelogin', 0);
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = "auth_outage";
-$plugin->version = 2026011305;          // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version = 2026011306;          // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release = 2026011305;          // Human-readable release information.
 $plugin->requires = 2025100600;         // Moodle 5.1.
 $plugin->maturity = MATURITY_STABLE;    // Suitable for PRODUCTION environments!


### PR DESCRIPTION
Moodle 5.2 enables force login by default ([MDL-87523](https://moodle.atlassian.net/browse/MDL-87523)), but some of our tests rely on it being off.